### PR TITLE
Handle Lights being outside the viewport

### DIFF
--- a/src/scene/layer/fogLayer/index.tsx
+++ b/src/scene/layer/fogLayer/index.tsx
@@ -293,6 +293,7 @@ const FogLayer: React.SFC<Props> = ({ layer, isTable, onUpdate, active }) => {
           displayIcon={!isTable}
           isTable={isTable}
           obstructionPolygons={layer.obstructionPolygons}
+          fogPolygons={layer.fogPolygons}
           onUpdate={(light) => {
             layer.lightSources[i] = light;
             onUpdate({ ...layer });


### PR DESCRIPTION
This PR fixes #45 by extending calculating the max lighting bounds, instead of using the table view poly.