### PR TITLE
Use protos for scene serialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@rehooks/component-size": "^1.0.3",
     "konva": "^8.3.1",
     "lru-cache": "^6.0.0",
+    "protobufjs": "^6.11.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-helmet": "^6.1.0",
@@ -26,7 +27,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "gen-proto": "protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./src/ --ts_proto_opt=esModuleInterop=true ./protos/*"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -50,6 +52,7 @@
     "@types/react-dom": "^16.9.8",
     "@types/react-helmet": "^6.0.0",
     "@types/react-router-dom": "^5.1.5",
-    "@types/uuid": "^8.0.0"
+    "@types/uuid": "^8.0.0",
+    "ts-proto": "^1.96.1"
   }
 }

--- a/protos/scene.proto
+++ b/protos/scene.proto
@@ -1,0 +1,99 @@
+syntax = "proto3";
+
+message Scene {
+  string id = 1;
+  string name = 2;
+  TableOptions table = 3;
+  repeated Layer layers = 4;
+}
+
+message TableOptions {
+  bool displayGrid = 1;
+  Vector2d offset = 2;
+  double rotation = 3;
+  double scale = 4;
+}
+
+message Vector2d {
+  double x = 1;
+  double y = 2;
+}
+
+message Layer {
+  oneof layerType {
+    AssetLayer assetLayer = 1;
+    FogLayer fogLayer = 2;
+  }
+}
+
+message AssetLayer {
+  string id = 1;
+  string name = 3;
+  bool visible = 4;
+
+  map<string, Asset> assets = 5;
+  message Asset {
+    string id = 1;
+
+    AssetType type = 2;
+    enum AssetType {
+      IMAGE = 0;
+      VIDEO = 1;
+    }
+
+    AssetSize size = 3;
+    message AssetSize {
+      double width = 1;
+      double height = 2;
+    }
+
+    AssetTransform transform = 4;
+    message AssetTransform {
+      double x = 1;
+      double y = 2;
+      double rotation = 3;
+      double width = 4;
+      double height = 5;
+    }
+
+    optional bool overrideCalibration = 5;
+
+    optional AssetCalibration calibration = 6;
+    message AssetCalibration {
+      float xOffset = 1;
+      float yOffset = 2;
+      float ppiX = 3;
+      float ppiY = 4;
+    }
+
+    optional bool snapToGrid = 7;
+  }
+}
+
+message FogLayer {
+  string id = 1;
+  string name = 3;
+  bool visible = 4;
+
+  repeated LightSource lightSources = 5;
+  message LightSource {
+    Vector2d position = 1;
+    float brightLightDistance = 2;
+    float dimLightDistance = 3;
+  }
+
+  repeated Polygon obstructionPolygons = 6;
+  repeated Polygon fogPolygons = 7;
+  repeated Polygon fogClearPolygons = 8;
+  message Polygon {
+    PolygonType type = 1;
+    enum PolygonType {
+      FOG = 0;
+      FOG_CLEAR = 1;
+      LIGHT_OBSTRUCTION = 2;
+    }
+
+    repeated Vector2d verticies = 2;
+    bool visibleOnTable = 3;
+  }
+}

--- a/protos/scene.proto
+++ b/protos/scene.proto
@@ -25,14 +25,19 @@ message Layer {
     AssetLayer assetLayer = 1;
     FogLayer fogLayer = 2;
   }
+  enum LayerType {
+    ASSETS = 0;
+    FOG = 1;
+  }
 }
 
 message AssetLayer {
   string id = 1;
   string name = 3;
   bool visible = 4;
+  Layer.LayerType type = 5;
 
-  map<string, Asset> assets = 5;
+  map<string, Asset> assets = 6;
   message Asset {
     string id = 1;
 
@@ -57,9 +62,7 @@ message AssetLayer {
       double height = 5;
     }
 
-    optional bool overrideCalibration = 5;
-
-    optional AssetCalibration calibration = 6;
+    optional AssetCalibration calibration = 5;
     message AssetCalibration {
       float xOffset = 1;
       float yOffset = 2;
@@ -67,7 +70,7 @@ message AssetLayer {
       float ppiY = 4;
     }
 
-    optional bool snapToGrid = 7;
+    optional bool snapToGrid = 6;
   }
 }
 
@@ -75,17 +78,18 @@ message FogLayer {
   string id = 1;
   string name = 3;
   bool visible = 4;
+  Layer.LayerType type = 5;
 
-  repeated LightSource lightSources = 5;
+  repeated LightSource lightSources = 6;
   message LightSource {
     Vector2d position = 1;
     float brightLightDistance = 2;
     float dimLightDistance = 3;
   }
 
-  repeated Polygon obstructionPolygons = 6;
-  repeated Polygon fogPolygons = 7;
-  repeated Polygon fogClearPolygons = 8;
+  repeated Polygon obstructionPolygons = 7;
+  repeated Polygon fogPolygons = 8;
+  repeated Polygon fogClearPolygons = 9;
   message Polygon {
     PolygonType type = 1;
     enum PolygonType {

--- a/protos/scene.proto
+++ b/protos/scene.proto
@@ -3,8 +3,9 @@ syntax = "proto3";
 message Scene {
   string id = 1;
   string name = 2;
-  TableOptions table = 3;
-  repeated Layer layers = 4;
+  uint64 version = 3;
+  TableOptions table = 4;
+  repeated Layer layers = 5;
 }
 
 message TableOptions {

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
     <title>D&amp;D Tabletop</title>
   </head>
-  <body>
+  <body style="background-color: black">
     <div id="root"></div>
   </body>
 </html>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,8 @@
 import ReactDOM from 'react-dom';
 
 import App from './App';
+import { migrate } from './scene/migrate';
 
-ReactDOM.render(<App/>, document.getElementById('root'));
+migrate().then(() => {
+  ReactDOM.render(<App/>, document.getElementById('root'));
+})

--- a/src/protos/scene.ts
+++ b/src/protos/scene.ts
@@ -1,0 +1,1518 @@
+/* eslint-disable */
+import Long from "long";
+import _m0 from "protobufjs/minimal";
+
+export const protobufPackage = "";
+
+export interface Scene {
+  id: string;
+  name: string;
+  table: TableOptions | undefined;
+  layers: Layer[];
+}
+
+export interface TableOptions {
+  displayGrid: boolean;
+  offset: Vector2d | undefined;
+  rotation: number;
+  scale: number;
+}
+
+export interface Vector2d {
+  x: number;
+  y: number;
+}
+
+export interface Layer {
+  assetLayer: AssetLayer | undefined;
+  fogLayer: FogLayer | undefined;
+}
+
+export interface AssetLayer {
+  id: string;
+  name: string;
+  visible: boolean;
+  assets: { [key: string]: AssetLayer_Asset };
+}
+
+export interface AssetLayer_AssetsEntry {
+  key: string;
+  value: AssetLayer_Asset | undefined;
+}
+
+export interface AssetLayer_Asset {
+  id: string;
+  type: AssetLayer_Asset_AssetType;
+  size: AssetLayer_Asset_AssetSize | undefined;
+  transform: AssetLayer_Asset_AssetTransform | undefined;
+  overrideCalibration?: boolean | undefined;
+  calibration?: AssetLayer_Asset_AssetCalibration | undefined;
+  snapToGrid?: boolean | undefined;
+}
+
+export enum AssetLayer_Asset_AssetType {
+  IMAGE = 0,
+  VIDEO = 1,
+  UNRECOGNIZED = -1,
+}
+
+export function assetLayer_Asset_AssetTypeFromJSON(
+  object: any
+): AssetLayer_Asset_AssetType {
+  switch (object) {
+    case 0:
+    case "IMAGE":
+      return AssetLayer_Asset_AssetType.IMAGE;
+    case 1:
+    case "VIDEO":
+      return AssetLayer_Asset_AssetType.VIDEO;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return AssetLayer_Asset_AssetType.UNRECOGNIZED;
+  }
+}
+
+export function assetLayer_Asset_AssetTypeToJSON(
+  object: AssetLayer_Asset_AssetType
+): string {
+  switch (object) {
+    case AssetLayer_Asset_AssetType.IMAGE:
+      return "IMAGE";
+    case AssetLayer_Asset_AssetType.VIDEO:
+      return "VIDEO";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+export interface AssetLayer_Asset_AssetSize {
+  width: number;
+  height: number;
+}
+
+export interface AssetLayer_Asset_AssetTransform {
+  x: number;
+  y: number;
+  rotation: number;
+  width: number;
+  height: number;
+}
+
+export interface AssetLayer_Asset_AssetCalibration {
+  xOffset: number;
+  yOffset: number;
+  ppiX: number;
+  ppiY: number;
+}
+
+export interface FogLayer {
+  id: string;
+  name: string;
+  visible: boolean;
+  lightSources: FogLayer_LightSource[];
+  obstructionPolygons: FogLayer_Polygon[];
+  fogPolygons: FogLayer_Polygon[];
+  fogClearPolygons: FogLayer_Polygon[];
+}
+
+export interface FogLayer_LightSource {
+  position: Vector2d | undefined;
+  brightLightDistance: number;
+  dimLightDistance: number;
+}
+
+export interface FogLayer_Polygon {
+  type: FogLayer_Polygon_PolygonType;
+  verticies: Vector2d[];
+  visibleOnTable: boolean;
+}
+
+export enum FogLayer_Polygon_PolygonType {
+  FOG = 0,
+  FOG_CLEAR = 1,
+  LIGHT_OBSTRUCTION = 2,
+  UNRECOGNIZED = -1,
+}
+
+export function fogLayer_Polygon_PolygonTypeFromJSON(
+  object: any
+): FogLayer_Polygon_PolygonType {
+  switch (object) {
+    case 0:
+    case "FOG":
+      return FogLayer_Polygon_PolygonType.FOG;
+    case 1:
+    case "FOG_CLEAR":
+      return FogLayer_Polygon_PolygonType.FOG_CLEAR;
+    case 2:
+    case "LIGHT_OBSTRUCTION":
+      return FogLayer_Polygon_PolygonType.LIGHT_OBSTRUCTION;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return FogLayer_Polygon_PolygonType.UNRECOGNIZED;
+  }
+}
+
+export function fogLayer_Polygon_PolygonTypeToJSON(
+  object: FogLayer_Polygon_PolygonType
+): string {
+  switch (object) {
+    case FogLayer_Polygon_PolygonType.FOG:
+      return "FOG";
+    case FogLayer_Polygon_PolygonType.FOG_CLEAR:
+      return "FOG_CLEAR";
+    case FogLayer_Polygon_PolygonType.LIGHT_OBSTRUCTION:
+      return "LIGHT_OBSTRUCTION";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+function createBaseScene(): Scene {
+  return { id: "", name: "", table: undefined, layers: [] };
+}
+
+export const Scene = {
+  encode(message: Scene, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.id !== "") {
+      writer.uint32(10).string(message.id);
+    }
+    if (message.name !== "") {
+      writer.uint32(18).string(message.name);
+    }
+    if (message.table !== undefined) {
+      TableOptions.encode(message.table, writer.uint32(26).fork()).ldelim();
+    }
+    for (const v of message.layers) {
+      Layer.encode(v!, writer.uint32(34).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Scene {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseScene();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = reader.string();
+          break;
+        case 2:
+          message.name = reader.string();
+          break;
+        case 3:
+          message.table = TableOptions.decode(reader, reader.uint32());
+          break;
+        case 4:
+          message.layers.push(Layer.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Scene {
+    const message = createBaseScene();
+    message.id =
+      object.id !== undefined && object.id !== null ? String(object.id) : "";
+    message.name =
+      object.name !== undefined && object.name !== null
+        ? String(object.name)
+        : "";
+    message.table =
+      object.table !== undefined && object.table !== null
+        ? TableOptions.fromJSON(object.table)
+        : undefined;
+    message.layers = (object.layers ?? []).map((e: any) => Layer.fromJSON(e));
+    return message;
+  },
+
+  toJSON(message: Scene): unknown {
+    const obj: any = {};
+    message.id !== undefined && (obj.id = message.id);
+    message.name !== undefined && (obj.name = message.name);
+    message.table !== undefined &&
+      (obj.table = message.table
+        ? TableOptions.toJSON(message.table)
+        : undefined);
+    if (message.layers) {
+      obj.layers = message.layers.map((e) => (e ? Layer.toJSON(e) : undefined));
+    } else {
+      obj.layers = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Scene>, I>>(object: I): Scene {
+    const message = createBaseScene();
+    message.id = object.id ?? "";
+    message.name = object.name ?? "";
+    message.table =
+      object.table !== undefined && object.table !== null
+        ? TableOptions.fromPartial(object.table)
+        : undefined;
+    message.layers = object.layers?.map((e) => Layer.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseTableOptions(): TableOptions {
+  return { displayGrid: false, offset: undefined, rotation: 0, scale: 0 };
+}
+
+export const TableOptions = {
+  encode(
+    message: TableOptions,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.displayGrid === true) {
+      writer.uint32(8).bool(message.displayGrid);
+    }
+    if (message.offset !== undefined) {
+      Vector2d.encode(message.offset, writer.uint32(18).fork()).ldelim();
+    }
+    if (message.rotation !== 0) {
+      writer.uint32(25).double(message.rotation);
+    }
+    if (message.scale !== 0) {
+      writer.uint32(33).double(message.scale);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): TableOptions {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTableOptions();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.displayGrid = reader.bool();
+          break;
+        case 2:
+          message.offset = Vector2d.decode(reader, reader.uint32());
+          break;
+        case 3:
+          message.rotation = reader.double();
+          break;
+        case 4:
+          message.scale = reader.double();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): TableOptions {
+    const message = createBaseTableOptions();
+    message.displayGrid =
+      object.displayGrid !== undefined && object.displayGrid !== null
+        ? Boolean(object.displayGrid)
+        : false;
+    message.offset =
+      object.offset !== undefined && object.offset !== null
+        ? Vector2d.fromJSON(object.offset)
+        : undefined;
+    message.rotation =
+      object.rotation !== undefined && object.rotation !== null
+        ? Number(object.rotation)
+        : 0;
+    message.scale =
+      object.scale !== undefined && object.scale !== null
+        ? Number(object.scale)
+        : 0;
+    return message;
+  },
+
+  toJSON(message: TableOptions): unknown {
+    const obj: any = {};
+    message.displayGrid !== undefined &&
+      (obj.displayGrid = message.displayGrid);
+    message.offset !== undefined &&
+      (obj.offset = message.offset
+        ? Vector2d.toJSON(message.offset)
+        : undefined);
+    message.rotation !== undefined && (obj.rotation = message.rotation);
+    message.scale !== undefined && (obj.scale = message.scale);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<TableOptions>, I>>(
+    object: I
+  ): TableOptions {
+    const message = createBaseTableOptions();
+    message.displayGrid = object.displayGrid ?? false;
+    message.offset =
+      object.offset !== undefined && object.offset !== null
+        ? Vector2d.fromPartial(object.offset)
+        : undefined;
+    message.rotation = object.rotation ?? 0;
+    message.scale = object.scale ?? 0;
+    return message;
+  },
+};
+
+function createBaseVector2d(): Vector2d {
+  return { x: 0, y: 0 };
+}
+
+export const Vector2d = {
+  encode(
+    message: Vector2d,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.x !== 0) {
+      writer.uint32(9).double(message.x);
+    }
+    if (message.y !== 0) {
+      writer.uint32(17).double(message.y);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Vector2d {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseVector2d();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.x = reader.double();
+          break;
+        case 2:
+          message.y = reader.double();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Vector2d {
+    const message = createBaseVector2d();
+    message.x =
+      object.x !== undefined && object.x !== null ? Number(object.x) : 0;
+    message.y =
+      object.y !== undefined && object.y !== null ? Number(object.y) : 0;
+    return message;
+  },
+
+  toJSON(message: Vector2d): unknown {
+    const obj: any = {};
+    message.x !== undefined && (obj.x = message.x);
+    message.y !== undefined && (obj.y = message.y);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Vector2d>, I>>(object: I): Vector2d {
+    const message = createBaseVector2d();
+    message.x = object.x ?? 0;
+    message.y = object.y ?? 0;
+    return message;
+  },
+};
+
+function createBaseLayer(): Layer {
+  return { assetLayer: undefined, fogLayer: undefined };
+}
+
+export const Layer = {
+  encode(message: Layer, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.assetLayer !== undefined) {
+      AssetLayer.encode(message.assetLayer, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.fogLayer !== undefined) {
+      FogLayer.encode(message.fogLayer, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Layer {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseLayer();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.assetLayer = AssetLayer.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.fogLayer = FogLayer.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Layer {
+    const message = createBaseLayer();
+    message.assetLayer =
+      object.assetLayer !== undefined && object.assetLayer !== null
+        ? AssetLayer.fromJSON(object.assetLayer)
+        : undefined;
+    message.fogLayer =
+      object.fogLayer !== undefined && object.fogLayer !== null
+        ? FogLayer.fromJSON(object.fogLayer)
+        : undefined;
+    return message;
+  },
+
+  toJSON(message: Layer): unknown {
+    const obj: any = {};
+    message.assetLayer !== undefined &&
+      (obj.assetLayer = message.assetLayer
+        ? AssetLayer.toJSON(message.assetLayer)
+        : undefined);
+    message.fogLayer !== undefined &&
+      (obj.fogLayer = message.fogLayer
+        ? FogLayer.toJSON(message.fogLayer)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Layer>, I>>(object: I): Layer {
+    const message = createBaseLayer();
+    message.assetLayer =
+      object.assetLayer !== undefined && object.assetLayer !== null
+        ? AssetLayer.fromPartial(object.assetLayer)
+        : undefined;
+    message.fogLayer =
+      object.fogLayer !== undefined && object.fogLayer !== null
+        ? FogLayer.fromPartial(object.fogLayer)
+        : undefined;
+    return message;
+  },
+};
+
+function createBaseAssetLayer(): AssetLayer {
+  return { id: "", name: "", visible: false, assets: {} };
+}
+
+export const AssetLayer = {
+  encode(
+    message: AssetLayer,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.id !== "") {
+      writer.uint32(10).string(message.id);
+    }
+    if (message.name !== "") {
+      writer.uint32(26).string(message.name);
+    }
+    if (message.visible === true) {
+      writer.uint32(32).bool(message.visible);
+    }
+    Object.entries(message.assets).forEach(([key, value]) => {
+      AssetLayer_AssetsEntry.encode(
+        { key: key as any, value },
+        writer.uint32(42).fork()
+      ).ldelim();
+    });
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): AssetLayer {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAssetLayer();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = reader.string();
+          break;
+        case 3:
+          message.name = reader.string();
+          break;
+        case 4:
+          message.visible = reader.bool();
+          break;
+        case 5:
+          const entry5 = AssetLayer_AssetsEntry.decode(reader, reader.uint32());
+          if (entry5.value !== undefined) {
+            message.assets[entry5.key] = entry5.value;
+          }
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AssetLayer {
+    const message = createBaseAssetLayer();
+    message.id =
+      object.id !== undefined && object.id !== null ? String(object.id) : "";
+    message.name =
+      object.name !== undefined && object.name !== null
+        ? String(object.name)
+        : "";
+    message.visible =
+      object.visible !== undefined && object.visible !== null
+        ? Boolean(object.visible)
+        : false;
+    message.assets = Object.entries(object.assets ?? {}).reduce<{
+      [key: string]: AssetLayer_Asset;
+    }>((acc, [key, value]) => {
+      acc[key] = AssetLayer_Asset.fromJSON(value);
+      return acc;
+    }, {});
+    return message;
+  },
+
+  toJSON(message: AssetLayer): unknown {
+    const obj: any = {};
+    message.id !== undefined && (obj.id = message.id);
+    message.name !== undefined && (obj.name = message.name);
+    message.visible !== undefined && (obj.visible = message.visible);
+    obj.assets = {};
+    if (message.assets) {
+      Object.entries(message.assets).forEach(([k, v]) => {
+        obj.assets[k] = AssetLayer_Asset.toJSON(v);
+      });
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<AssetLayer>, I>>(
+    object: I
+  ): AssetLayer {
+    const message = createBaseAssetLayer();
+    message.id = object.id ?? "";
+    message.name = object.name ?? "";
+    message.visible = object.visible ?? false;
+    message.assets = Object.entries(object.assets ?? {}).reduce<{
+      [key: string]: AssetLayer_Asset;
+    }>((acc, [key, value]) => {
+      if (value !== undefined) {
+        acc[key] = AssetLayer_Asset.fromPartial(value);
+      }
+      return acc;
+    }, {});
+    return message;
+  },
+};
+
+function createBaseAssetLayer_AssetsEntry(): AssetLayer_AssetsEntry {
+  return { key: "", value: undefined };
+}
+
+export const AssetLayer_AssetsEntry = {
+  encode(
+    message: AssetLayer_AssetsEntry,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.key !== "") {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.value !== undefined) {
+      AssetLayer_Asset.encode(message.value, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): AssetLayer_AssetsEntry {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAssetLayer_AssetsEntry();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.key = reader.string();
+          break;
+        case 2:
+          message.value = AssetLayer_Asset.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AssetLayer_AssetsEntry {
+    const message = createBaseAssetLayer_AssetsEntry();
+    message.key =
+      object.key !== undefined && object.key !== null ? String(object.key) : "";
+    message.value =
+      object.value !== undefined && object.value !== null
+        ? AssetLayer_Asset.fromJSON(object.value)
+        : undefined;
+    return message;
+  },
+
+  toJSON(message: AssetLayer_AssetsEntry): unknown {
+    const obj: any = {};
+    message.key !== undefined && (obj.key = message.key);
+    message.value !== undefined &&
+      (obj.value = message.value
+        ? AssetLayer_Asset.toJSON(message.value)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<AssetLayer_AssetsEntry>, I>>(
+    object: I
+  ): AssetLayer_AssetsEntry {
+    const message = createBaseAssetLayer_AssetsEntry();
+    message.key = object.key ?? "";
+    message.value =
+      object.value !== undefined && object.value !== null
+        ? AssetLayer_Asset.fromPartial(object.value)
+        : undefined;
+    return message;
+  },
+};
+
+function createBaseAssetLayer_Asset(): AssetLayer_Asset {
+  return {
+    id: "",
+    type: 0,
+    size: undefined,
+    transform: undefined,
+    overrideCalibration: undefined,
+    calibration: undefined,
+    snapToGrid: undefined,
+  };
+}
+
+export const AssetLayer_Asset = {
+  encode(
+    message: AssetLayer_Asset,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.id !== "") {
+      writer.uint32(10).string(message.id);
+    }
+    if (message.type !== 0) {
+      writer.uint32(16).int32(message.type);
+    }
+    if (message.size !== undefined) {
+      AssetLayer_Asset_AssetSize.encode(
+        message.size,
+        writer.uint32(26).fork()
+      ).ldelim();
+    }
+    if (message.transform !== undefined) {
+      AssetLayer_Asset_AssetTransform.encode(
+        message.transform,
+        writer.uint32(34).fork()
+      ).ldelim();
+    }
+    if (message.overrideCalibration !== undefined) {
+      writer.uint32(40).bool(message.overrideCalibration);
+    }
+    if (message.calibration !== undefined) {
+      AssetLayer_Asset_AssetCalibration.encode(
+        message.calibration,
+        writer.uint32(50).fork()
+      ).ldelim();
+    }
+    if (message.snapToGrid !== undefined) {
+      writer.uint32(56).bool(message.snapToGrid);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): AssetLayer_Asset {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAssetLayer_Asset();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = reader.string();
+          break;
+        case 2:
+          message.type = reader.int32() as any;
+          break;
+        case 3:
+          message.size = AssetLayer_Asset_AssetSize.decode(
+            reader,
+            reader.uint32()
+          );
+          break;
+        case 4:
+          message.transform = AssetLayer_Asset_AssetTransform.decode(
+            reader,
+            reader.uint32()
+          );
+          break;
+        case 5:
+          message.overrideCalibration = reader.bool();
+          break;
+        case 6:
+          message.calibration = AssetLayer_Asset_AssetCalibration.decode(
+            reader,
+            reader.uint32()
+          );
+          break;
+        case 7:
+          message.snapToGrid = reader.bool();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AssetLayer_Asset {
+    const message = createBaseAssetLayer_Asset();
+    message.id =
+      object.id !== undefined && object.id !== null ? String(object.id) : "";
+    message.type =
+      object.type !== undefined && object.type !== null
+        ? assetLayer_Asset_AssetTypeFromJSON(object.type)
+        : 0;
+    message.size =
+      object.size !== undefined && object.size !== null
+        ? AssetLayer_Asset_AssetSize.fromJSON(object.size)
+        : undefined;
+    message.transform =
+      object.transform !== undefined && object.transform !== null
+        ? AssetLayer_Asset_AssetTransform.fromJSON(object.transform)
+        : undefined;
+    message.overrideCalibration =
+      object.overrideCalibration !== undefined &&
+      object.overrideCalibration !== null
+        ? Boolean(object.overrideCalibration)
+        : undefined;
+    message.calibration =
+      object.calibration !== undefined && object.calibration !== null
+        ? AssetLayer_Asset_AssetCalibration.fromJSON(object.calibration)
+        : undefined;
+    message.snapToGrid =
+      object.snapToGrid !== undefined && object.snapToGrid !== null
+        ? Boolean(object.snapToGrid)
+        : undefined;
+    return message;
+  },
+
+  toJSON(message: AssetLayer_Asset): unknown {
+    const obj: any = {};
+    message.id !== undefined && (obj.id = message.id);
+    message.type !== undefined &&
+      (obj.type = assetLayer_Asset_AssetTypeToJSON(message.type));
+    message.size !== undefined &&
+      (obj.size = message.size
+        ? AssetLayer_Asset_AssetSize.toJSON(message.size)
+        : undefined);
+    message.transform !== undefined &&
+      (obj.transform = message.transform
+        ? AssetLayer_Asset_AssetTransform.toJSON(message.transform)
+        : undefined);
+    message.overrideCalibration !== undefined &&
+      (obj.overrideCalibration = message.overrideCalibration);
+    message.calibration !== undefined &&
+      (obj.calibration = message.calibration
+        ? AssetLayer_Asset_AssetCalibration.toJSON(message.calibration)
+        : undefined);
+    message.snapToGrid !== undefined && (obj.snapToGrid = message.snapToGrid);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<AssetLayer_Asset>, I>>(
+    object: I
+  ): AssetLayer_Asset {
+    const message = createBaseAssetLayer_Asset();
+    message.id = object.id ?? "";
+    message.type = object.type ?? 0;
+    message.size =
+      object.size !== undefined && object.size !== null
+        ? AssetLayer_Asset_AssetSize.fromPartial(object.size)
+        : undefined;
+    message.transform =
+      object.transform !== undefined && object.transform !== null
+        ? AssetLayer_Asset_AssetTransform.fromPartial(object.transform)
+        : undefined;
+    message.overrideCalibration = object.overrideCalibration ?? undefined;
+    message.calibration =
+      object.calibration !== undefined && object.calibration !== null
+        ? AssetLayer_Asset_AssetCalibration.fromPartial(object.calibration)
+        : undefined;
+    message.snapToGrid = object.snapToGrid ?? undefined;
+    return message;
+  },
+};
+
+function createBaseAssetLayer_Asset_AssetSize(): AssetLayer_Asset_AssetSize {
+  return { width: 0, height: 0 };
+}
+
+export const AssetLayer_Asset_AssetSize = {
+  encode(
+    message: AssetLayer_Asset_AssetSize,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.width !== 0) {
+      writer.uint32(9).double(message.width);
+    }
+    if (message.height !== 0) {
+      writer.uint32(17).double(message.height);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): AssetLayer_Asset_AssetSize {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAssetLayer_Asset_AssetSize();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.width = reader.double();
+          break;
+        case 2:
+          message.height = reader.double();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AssetLayer_Asset_AssetSize {
+    const message = createBaseAssetLayer_Asset_AssetSize();
+    message.width =
+      object.width !== undefined && object.width !== null
+        ? Number(object.width)
+        : 0;
+    message.height =
+      object.height !== undefined && object.height !== null
+        ? Number(object.height)
+        : 0;
+    return message;
+  },
+
+  toJSON(message: AssetLayer_Asset_AssetSize): unknown {
+    const obj: any = {};
+    message.width !== undefined && (obj.width = message.width);
+    message.height !== undefined && (obj.height = message.height);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<AssetLayer_Asset_AssetSize>, I>>(
+    object: I
+  ): AssetLayer_Asset_AssetSize {
+    const message = createBaseAssetLayer_Asset_AssetSize();
+    message.width = object.width ?? 0;
+    message.height = object.height ?? 0;
+    return message;
+  },
+};
+
+function createBaseAssetLayer_Asset_AssetTransform(): AssetLayer_Asset_AssetTransform {
+  return { x: 0, y: 0, rotation: 0, width: 0, height: 0 };
+}
+
+export const AssetLayer_Asset_AssetTransform = {
+  encode(
+    message: AssetLayer_Asset_AssetTransform,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.x !== 0) {
+      writer.uint32(9).double(message.x);
+    }
+    if (message.y !== 0) {
+      writer.uint32(17).double(message.y);
+    }
+    if (message.rotation !== 0) {
+      writer.uint32(25).double(message.rotation);
+    }
+    if (message.width !== 0) {
+      writer.uint32(33).double(message.width);
+    }
+    if (message.height !== 0) {
+      writer.uint32(41).double(message.height);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): AssetLayer_Asset_AssetTransform {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAssetLayer_Asset_AssetTransform();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.x = reader.double();
+          break;
+        case 2:
+          message.y = reader.double();
+          break;
+        case 3:
+          message.rotation = reader.double();
+          break;
+        case 4:
+          message.width = reader.double();
+          break;
+        case 5:
+          message.height = reader.double();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AssetLayer_Asset_AssetTransform {
+    const message = createBaseAssetLayer_Asset_AssetTransform();
+    message.x =
+      object.x !== undefined && object.x !== null ? Number(object.x) : 0;
+    message.y =
+      object.y !== undefined && object.y !== null ? Number(object.y) : 0;
+    message.rotation =
+      object.rotation !== undefined && object.rotation !== null
+        ? Number(object.rotation)
+        : 0;
+    message.width =
+      object.width !== undefined && object.width !== null
+        ? Number(object.width)
+        : 0;
+    message.height =
+      object.height !== undefined && object.height !== null
+        ? Number(object.height)
+        : 0;
+    return message;
+  },
+
+  toJSON(message: AssetLayer_Asset_AssetTransform): unknown {
+    const obj: any = {};
+    message.x !== undefined && (obj.x = message.x);
+    message.y !== undefined && (obj.y = message.y);
+    message.rotation !== undefined && (obj.rotation = message.rotation);
+    message.width !== undefined && (obj.width = message.width);
+    message.height !== undefined && (obj.height = message.height);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<AssetLayer_Asset_AssetTransform>, I>>(
+    object: I
+  ): AssetLayer_Asset_AssetTransform {
+    const message = createBaseAssetLayer_Asset_AssetTransform();
+    message.x = object.x ?? 0;
+    message.y = object.y ?? 0;
+    message.rotation = object.rotation ?? 0;
+    message.width = object.width ?? 0;
+    message.height = object.height ?? 0;
+    return message;
+  },
+};
+
+function createBaseAssetLayer_Asset_AssetCalibration(): AssetLayer_Asset_AssetCalibration {
+  return { xOffset: 0, yOffset: 0, ppiX: 0, ppiY: 0 };
+}
+
+export const AssetLayer_Asset_AssetCalibration = {
+  encode(
+    message: AssetLayer_Asset_AssetCalibration,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.xOffset !== 0) {
+      writer.uint32(13).float(message.xOffset);
+    }
+    if (message.yOffset !== 0) {
+      writer.uint32(21).float(message.yOffset);
+    }
+    if (message.ppiX !== 0) {
+      writer.uint32(29).float(message.ppiX);
+    }
+    if (message.ppiY !== 0) {
+      writer.uint32(37).float(message.ppiY);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): AssetLayer_Asset_AssetCalibration {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAssetLayer_Asset_AssetCalibration();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.xOffset = reader.float();
+          break;
+        case 2:
+          message.yOffset = reader.float();
+          break;
+        case 3:
+          message.ppiX = reader.float();
+          break;
+        case 4:
+          message.ppiY = reader.float();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AssetLayer_Asset_AssetCalibration {
+    const message = createBaseAssetLayer_Asset_AssetCalibration();
+    message.xOffset =
+      object.xOffset !== undefined && object.xOffset !== null
+        ? Number(object.xOffset)
+        : 0;
+    message.yOffset =
+      object.yOffset !== undefined && object.yOffset !== null
+        ? Number(object.yOffset)
+        : 0;
+    message.ppiX =
+      object.ppiX !== undefined && object.ppiX !== null
+        ? Number(object.ppiX)
+        : 0;
+    message.ppiY =
+      object.ppiY !== undefined && object.ppiY !== null
+        ? Number(object.ppiY)
+        : 0;
+    return message;
+  },
+
+  toJSON(message: AssetLayer_Asset_AssetCalibration): unknown {
+    const obj: any = {};
+    message.xOffset !== undefined && (obj.xOffset = message.xOffset);
+    message.yOffset !== undefined && (obj.yOffset = message.yOffset);
+    message.ppiX !== undefined && (obj.ppiX = message.ppiX);
+    message.ppiY !== undefined && (obj.ppiY = message.ppiY);
+    return obj;
+  },
+
+  fromPartial<
+    I extends Exact<DeepPartial<AssetLayer_Asset_AssetCalibration>, I>
+  >(object: I): AssetLayer_Asset_AssetCalibration {
+    const message = createBaseAssetLayer_Asset_AssetCalibration();
+    message.xOffset = object.xOffset ?? 0;
+    message.yOffset = object.yOffset ?? 0;
+    message.ppiX = object.ppiX ?? 0;
+    message.ppiY = object.ppiY ?? 0;
+    return message;
+  },
+};
+
+function createBaseFogLayer(): FogLayer {
+  return {
+    id: "",
+    name: "",
+    visible: false,
+    lightSources: [],
+    obstructionPolygons: [],
+    fogPolygons: [],
+    fogClearPolygons: [],
+  };
+}
+
+export const FogLayer = {
+  encode(
+    message: FogLayer,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.id !== "") {
+      writer.uint32(10).string(message.id);
+    }
+    if (message.name !== "") {
+      writer.uint32(26).string(message.name);
+    }
+    if (message.visible === true) {
+      writer.uint32(32).bool(message.visible);
+    }
+    for (const v of message.lightSources) {
+      FogLayer_LightSource.encode(v!, writer.uint32(42).fork()).ldelim();
+    }
+    for (const v of message.obstructionPolygons) {
+      FogLayer_Polygon.encode(v!, writer.uint32(50).fork()).ldelim();
+    }
+    for (const v of message.fogPolygons) {
+      FogLayer_Polygon.encode(v!, writer.uint32(58).fork()).ldelim();
+    }
+    for (const v of message.fogClearPolygons) {
+      FogLayer_Polygon.encode(v!, writer.uint32(66).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): FogLayer {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseFogLayer();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = reader.string();
+          break;
+        case 3:
+          message.name = reader.string();
+          break;
+        case 4:
+          message.visible = reader.bool();
+          break;
+        case 5:
+          message.lightSources.push(
+            FogLayer_LightSource.decode(reader, reader.uint32())
+          );
+          break;
+        case 6:
+          message.obstructionPolygons.push(
+            FogLayer_Polygon.decode(reader, reader.uint32())
+          );
+          break;
+        case 7:
+          message.fogPolygons.push(
+            FogLayer_Polygon.decode(reader, reader.uint32())
+          );
+          break;
+        case 8:
+          message.fogClearPolygons.push(
+            FogLayer_Polygon.decode(reader, reader.uint32())
+          );
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): FogLayer {
+    const message = createBaseFogLayer();
+    message.id =
+      object.id !== undefined && object.id !== null ? String(object.id) : "";
+    message.name =
+      object.name !== undefined && object.name !== null
+        ? String(object.name)
+        : "";
+    message.visible =
+      object.visible !== undefined && object.visible !== null
+        ? Boolean(object.visible)
+        : false;
+    message.lightSources = (object.lightSources ?? []).map((e: any) =>
+      FogLayer_LightSource.fromJSON(e)
+    );
+    message.obstructionPolygons = (object.obstructionPolygons ?? []).map(
+      (e: any) => FogLayer_Polygon.fromJSON(e)
+    );
+    message.fogPolygons = (object.fogPolygons ?? []).map((e: any) =>
+      FogLayer_Polygon.fromJSON(e)
+    );
+    message.fogClearPolygons = (object.fogClearPolygons ?? []).map((e: any) =>
+      FogLayer_Polygon.fromJSON(e)
+    );
+    return message;
+  },
+
+  toJSON(message: FogLayer): unknown {
+    const obj: any = {};
+    message.id !== undefined && (obj.id = message.id);
+    message.name !== undefined && (obj.name = message.name);
+    message.visible !== undefined && (obj.visible = message.visible);
+    if (message.lightSources) {
+      obj.lightSources = message.lightSources.map((e) =>
+        e ? FogLayer_LightSource.toJSON(e) : undefined
+      );
+    } else {
+      obj.lightSources = [];
+    }
+    if (message.obstructionPolygons) {
+      obj.obstructionPolygons = message.obstructionPolygons.map((e) =>
+        e ? FogLayer_Polygon.toJSON(e) : undefined
+      );
+    } else {
+      obj.obstructionPolygons = [];
+    }
+    if (message.fogPolygons) {
+      obj.fogPolygons = message.fogPolygons.map((e) =>
+        e ? FogLayer_Polygon.toJSON(e) : undefined
+      );
+    } else {
+      obj.fogPolygons = [];
+    }
+    if (message.fogClearPolygons) {
+      obj.fogClearPolygons = message.fogClearPolygons.map((e) =>
+        e ? FogLayer_Polygon.toJSON(e) : undefined
+      );
+    } else {
+      obj.fogClearPolygons = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<FogLayer>, I>>(object: I): FogLayer {
+    const message = createBaseFogLayer();
+    message.id = object.id ?? "";
+    message.name = object.name ?? "";
+    message.visible = object.visible ?? false;
+    message.lightSources =
+      object.lightSources?.map((e) => FogLayer_LightSource.fromPartial(e)) ||
+      [];
+    message.obstructionPolygons =
+      object.obstructionPolygons?.map((e) => FogLayer_Polygon.fromPartial(e)) ||
+      [];
+    message.fogPolygons =
+      object.fogPolygons?.map((e) => FogLayer_Polygon.fromPartial(e)) || [];
+    message.fogClearPolygons =
+      object.fogClearPolygons?.map((e) => FogLayer_Polygon.fromPartial(e)) ||
+      [];
+    return message;
+  },
+};
+
+function createBaseFogLayer_LightSource(): FogLayer_LightSource {
+  return { position: undefined, brightLightDistance: 0, dimLightDistance: 0 };
+}
+
+export const FogLayer_LightSource = {
+  encode(
+    message: FogLayer_LightSource,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.position !== undefined) {
+      Vector2d.encode(message.position, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.brightLightDistance !== 0) {
+      writer.uint32(21).float(message.brightLightDistance);
+    }
+    if (message.dimLightDistance !== 0) {
+      writer.uint32(29).float(message.dimLightDistance);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): FogLayer_LightSource {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseFogLayer_LightSource();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.position = Vector2d.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.brightLightDistance = reader.float();
+          break;
+        case 3:
+          message.dimLightDistance = reader.float();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): FogLayer_LightSource {
+    const message = createBaseFogLayer_LightSource();
+    message.position =
+      object.position !== undefined && object.position !== null
+        ? Vector2d.fromJSON(object.position)
+        : undefined;
+    message.brightLightDistance =
+      object.brightLightDistance !== undefined &&
+      object.brightLightDistance !== null
+        ? Number(object.brightLightDistance)
+        : 0;
+    message.dimLightDistance =
+      object.dimLightDistance !== undefined && object.dimLightDistance !== null
+        ? Number(object.dimLightDistance)
+        : 0;
+    return message;
+  },
+
+  toJSON(message: FogLayer_LightSource): unknown {
+    const obj: any = {};
+    message.position !== undefined &&
+      (obj.position = message.position
+        ? Vector2d.toJSON(message.position)
+        : undefined);
+    message.brightLightDistance !== undefined &&
+      (obj.brightLightDistance = message.brightLightDistance);
+    message.dimLightDistance !== undefined &&
+      (obj.dimLightDistance = message.dimLightDistance);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<FogLayer_LightSource>, I>>(
+    object: I
+  ): FogLayer_LightSource {
+    const message = createBaseFogLayer_LightSource();
+    message.position =
+      object.position !== undefined && object.position !== null
+        ? Vector2d.fromPartial(object.position)
+        : undefined;
+    message.brightLightDistance = object.brightLightDistance ?? 0;
+    message.dimLightDistance = object.dimLightDistance ?? 0;
+    return message;
+  },
+};
+
+function createBaseFogLayer_Polygon(): FogLayer_Polygon {
+  return { type: 0, verticies: [], visibleOnTable: false };
+}
+
+export const FogLayer_Polygon = {
+  encode(
+    message: FogLayer_Polygon,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.type !== 0) {
+      writer.uint32(8).int32(message.type);
+    }
+    for (const v of message.verticies) {
+      Vector2d.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    if (message.visibleOnTable === true) {
+      writer.uint32(24).bool(message.visibleOnTable);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): FogLayer_Polygon {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseFogLayer_Polygon();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.type = reader.int32() as any;
+          break;
+        case 2:
+          message.verticies.push(Vector2d.decode(reader, reader.uint32()));
+          break;
+        case 3:
+          message.visibleOnTable = reader.bool();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): FogLayer_Polygon {
+    const message = createBaseFogLayer_Polygon();
+    message.type =
+      object.type !== undefined && object.type !== null
+        ? fogLayer_Polygon_PolygonTypeFromJSON(object.type)
+        : 0;
+    message.verticies = (object.verticies ?? []).map((e: any) =>
+      Vector2d.fromJSON(e)
+    );
+    message.visibleOnTable =
+      object.visibleOnTable !== undefined && object.visibleOnTable !== null
+        ? Boolean(object.visibleOnTable)
+        : false;
+    return message;
+  },
+
+  toJSON(message: FogLayer_Polygon): unknown {
+    const obj: any = {};
+    message.type !== undefined &&
+      (obj.type = fogLayer_Polygon_PolygonTypeToJSON(message.type));
+    if (message.verticies) {
+      obj.verticies = message.verticies.map((e) =>
+        e ? Vector2d.toJSON(e) : undefined
+      );
+    } else {
+      obj.verticies = [];
+    }
+    message.visibleOnTable !== undefined &&
+      (obj.visibleOnTable = message.visibleOnTable);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<FogLayer_Polygon>, I>>(
+    object: I
+  ): FogLayer_Polygon {
+    const message = createBaseFogLayer_Polygon();
+    message.type = object.type ?? 0;
+    message.verticies =
+      object.verticies?.map((e) => Vector2d.fromPartial(e)) || [];
+    message.visibleOnTable = object.visibleOnTable ?? false;
+    return message;
+  },
+};
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P>>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}

--- a/src/scene/canvas/addLayerButton.tsx
+++ b/src/scene/canvas/addLayerButton.tsx
@@ -11,14 +11,14 @@ import AddOutlinedIcon from '@mui/icons-material/AddOutlined';
 import ImageOutlinedIcon from '@mui/icons-material/ImageOutlined';
 import CloudOutlinedIcon from '@mui/icons-material/CloudOutlined';
 
-import LayerType from "../layer/layerType";
+import { Layer_LayerType } from "../../protos/scene";
 
-type Props = { onAdd: (type: LayerType) => void; };
+type Props = { onAdd: (type: Layer_LayerType) => void; };
 const AddLayerButton: React.FunctionComponent<Props> = ({ onAdd }) => {
   const [showMenu, setShowMenu] = useState(false);
   const anchorEl = useRef<HTMLElement>();
 
-  const addLayer = (type: LayerType) => () => {
+  const addLayer = (type: Layer_LayerType) => () => {
     setShowMenu(false);
     onAdd(type);
   }
@@ -39,11 +39,11 @@ const AddLayerButton: React.FunctionComponent<Props> = ({ onAdd }) => {
         open={showMenu}
         onClose={() => setShowMenu(false)}
       >
-        <MenuItem onClick={addLayer(LayerType.ASSETS)}>
+        <MenuItem onClick={addLayer(Layer_LayerType.ASSETS)}>
           <ListItemIcon><ImageOutlinedIcon /></ListItemIcon>
           <ListItemText primary="Asset Layer" />
         </MenuItem>
-        <MenuItem onClick={addLayer(LayerType.FOG)}>
+        <MenuItem onClick={addLayer(Layer_LayerType.FOG)}>
           <ListItemIcon><CloudOutlinedIcon /></ListItemIcon>
           <ListItemText primary="Fog Layer" />
         </MenuItem>

--- a/src/scene/canvas/deleteLayerButton.tsx
+++ b/src/scene/canvas/deleteLayerButton.tsx
@@ -6,13 +6,13 @@ import Tooltip from '@mui/material/Tooltip';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 
 import { ILayer } from "../layer";
-import { TableViewLayer } from "../layer/tableView";
 import ConfirmDialog from "../../partials/confirmDialog";
+import { TABLEVIEW_LAYER_ID } from "../layer/tableView";
 
 type Props = { layer?: ILayer; onDelete: () => void; };
 const DeleteLayerButton: React.FunctionComponent<Props> = ({ layer, onDelete }) => {
   const [showModal, setShowModal] = useState(false);
-  const disabled = !layer || layer.id === TableViewLayer.id;
+  const disabled = !layer || layer.id === TABLEVIEW_LAYER_ID;
 
   return (
     <>

--- a/src/scene/canvas/editLayerButton.tsx
+++ b/src/scene/canvas/editLayerButton.tsx
@@ -6,14 +6,14 @@ import Tooltip from '@mui/material/Tooltip';
 import DriveFileRenameOutlineOutlinedIcon from '@mui/icons-material/DriveFileRenameOutlineOutlined';
 
 import { ILayer } from "../layer";
-import { TableViewLayer } from "../layer/tableView";
 import RenameDialog from "../../partials/renameDialog";
+import { TABLEVIEW_LAYER_ID } from "../layer/tableView";
 
 type Props = { layer?: ILayer; onUpdate: (layer: ILayer) => void; };
 const EditLayerButton: React.FunctionComponent<Props> = ({ layer, onUpdate }) => {
   const [showModal, setShowModal] = useState(false);
 
-  const disabled = !layer || layer.id === TableViewLayer.id;
+  const disabled = !layer || layer.id === TABLEVIEW_LAYER_ID;
 
   return (
     <>

--- a/src/scene/canvas/index.tsx
+++ b/src/scene/canvas/index.tsx
@@ -1,23 +1,17 @@
-import React, { useState, useEffect, useCallback, useContext, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import Konva from 'konva';
 import useComponentSize from '@rehooks/component-size';
 
 import Box from '@mui/material/Box'
 
-import { IScene } from '..';
 import DraggableStage from './draggableStage';
-import { LayerTypeToComponent, ILayer, createNewLayer } from '../layer';
-import LayerType from "../layer/layerType";
+import { LayerTypeToComponent, ILayer, createNewLayer, flattenLayer, unflattenLayer } from '../layer';
 import { deleteLayer } from '../layer';
 import LayerList from './layerList';
 import { ToolbarPortalProvider } from '../layer/toolbarPortal';
-import TableViewOverlay, { TableViewLayer } from '../layer/tableView';
+import TableViewOverlay, { TABLEVIEW_LAYER_ID } from '../layer/tableView';
 import { useTableDimensions } from '../../settings';
-
-export const CurrentSceneContext = React.createContext<IScene | null>(null);
-export function useCurrentScene() {
-	return useContext(CurrentSceneContext);
-}
+import * as Types from '../../protos/scene';
 
 export function calculateViewportCenter(layerRef: React.MutableRefObject<Konva.Layer | undefined>): Konva.Vector2d {
 	if (layerRef.current) {
@@ -56,61 +50,55 @@ export function calculateViewportDimensions(layerRef: React.MutableRefObject<Kon
 	}
 }
 
-type Props = { scene: IScene, onUpdate: (scene: IScene) => void };
-const Canvas: React.SFC<Props> = ({ scene, onUpdate }) => {
+type Props = { scene: Types.Scene, onUpdate: (scene: Types.Scene) => void };
+const Canvas: React.FunctionComponent<Props> = ({ scene, onUpdate }) => {
 	const [activeLayerId, setActiveLayerId] = useState<string | null>(null);
 	const containerRef = useRef<HTMLDivElement>();
 	const containerSize = useComponentSize(containerRef);
 	const tableDimensions = useTableDimensions();
+	const layers = scene.layers.map(flattenLayer);
 
 	// Default selected layer to the first layer
 	useEffect(() => {
-		if (activeLayerId === TableViewLayer.id) return;
+		if (activeLayerId === TABLEVIEW_LAYER_ID) return;
 
 		if (
-			(activeLayerId === null || !scene.layers.some((l) => l.id === activeLayerId)) &&
-			scene.layers.length
+			(activeLayerId === null || !layers.some((l) => l.id === activeLayerId)) && layers.length
 		) {
-			setActiveLayerId(scene.layers[0].id);
+			setActiveLayerId(layers[0].id);
 		}
-	}, [activeLayerId, scene])
+	}, [activeLayerId, layers])
 
 	const onLayerUpdate = useCallback((updatedLayer: ILayer) => {
-		const i = scene.layers.findIndex((l) => l.id === updatedLayer.id);
-		scene.layers[i] = updatedLayer;
-		onUpdate({ ...scene })
-	}, [scene, onUpdate]);
+		const i = layers.findIndex((l) => l.id === updatedLayer.id);
+		scene.layers[i] = unflattenLayer(updatedLayer)
+		onUpdate(scene)
+	}, [scene, layers, onUpdate]);
 
-	function addLayer(type: LayerType) {
+	const addLayer = useCallback((type: Types.Layer_LayerType) => {
 		const layer = createNewLayer(type);
-		layer.name = 'Layer ' + (scene.layers.length + 1);
-		scene.layers.push(layer);
+		layer.name = 'Layer ' + (layers.length + 1);
+		scene.layers.push(unflattenLayer(layer));
 		setActiveLayerId(layer.id);
-		onUpdate({ ...scene });
-	}
+		onUpdate(scene);
+	}, [layers.length, onUpdate, scene])
 
-	function updateLayer(layer: ILayer) {
-		const index = scene.layers.findIndex((l) => l.id === layer.id);
-		scene.layers[index] = layer;
-		onUpdate({
-			...scene,
-			layers: [...scene.layers]
-		});
-	}
+	const updateLayer = useCallback((layer: ILayer) => {
+		const index = layers.findIndex((l) => l.id === layer.id);
+		scene.layers[index] = unflattenLayer(layer);
+		onUpdate(scene);
+	}, [layers, onUpdate, scene])
 
-	function editActiveLayerName(name: string) {
-		const layer = scene.layers.find((l) => l.id === activeLayerId);
+	const editActiveLayerName = useCallback((name: string) => {
+		const layer = scene.layers.map(flattenLayer).find((l) => l.id === activeLayerId);
 		if (!layer) return;
 
 		layer.name = name;
-		onUpdate({
-			...scene,
-			layers: [...scene.layers]
-		});
-	}
+		onUpdate(scene);
+	}, [activeLayerId, onUpdate, scene])
 
-	function moveActiveLayer(direction: 'up' | 'down') {
-		const layerIndex = scene.layers.findIndex((l) => l.id === activeLayerId);
+	const moveActiveLayer = useCallback((direction: 'up' | 'down') => {
+		const layerIndex = layers.findIndex((l) => l.id === activeLayerId);
 		if (layerIndex !== -1) {
 			const swapIndex = direction === 'up' ? layerIndex + 1 : layerIndex - 1;
 			if (swapIndex > scene.layers.length - 1 || swapIndex < 0) {
@@ -122,25 +110,20 @@ const Canvas: React.SFC<Props> = ({ scene, onUpdate }) => {
 
 			scene.layers[swapIndex] = currentLayer;
 			scene.layers[layerIndex] = layerToSwap;
+			scene.layers = Array.from(scene.layers);
 
-			onUpdate({
-				...scene,
-				layers: [...scene.layers]
-			});
+			onUpdate(scene);
 		}
-	}
+	}, [activeLayerId, layers, onUpdate, scene])
 
-	async function deleteActiveLayer() {
-		const layer = scene.layers.find((l) => l.id === activeLayerId);
+	const deleteActiveLayer = useCallback(async () => {
+		const layer = scene.layers.map(flattenLayer).find((l) => l.id === activeLayerId);
 		if (layer) {
 			const newScene = await deleteLayer(scene, layer);
-			onUpdate({
-				...newScene,
-				layers: [...newScene.layers]
-			});
+			onUpdate(newScene);
 			setActiveLayerId(null);
 		}
-	}
+	}, [activeLayerId, onUpdate, scene])
 
 	const initialZoom = tableDimensions ?
 		Math.min(
@@ -166,46 +149,40 @@ const Canvas: React.SFC<Props> = ({ scene, onUpdate }) => {
 							height={containerSize.height || 1}
 							initialZoom={initialZoom}
 						>
-							<CurrentSceneContext.Provider value={scene}>
-								{
-									scene.layers.map((layer) => {
-										const Component = LayerTypeToComponent[layer.type];
-										if (!Component || layer.visible === false) return null;
-										return (
-											<Component
-												key={layer.id}
-												layer={layer}
-												isTable={false}
-												onUpdate={onLayerUpdate}
-												active={activeLayerId === layer.id}
-											/>
-										);
+							{
+								scene.layers.map(flattenLayer).map((layer) => {
+									const Component = LayerTypeToComponent[layer.type];
+									if (!Component || layer.visible === false) return null;
+									return (
+										<Component
+											key={layer.id}
+											layer={layer}
+											isTable={false}
+											onUpdate={onLayerUpdate}
+											active={activeLayerId === layer.id}
+										/>
+									);
+								})
+							}
+							<TableViewOverlay
+								options={scene.table!}
+								active={activeLayerId === TABLEVIEW_LAYER_ID}
+								onUpdate={(options) => {
+									onUpdate({
+										...scene,
+										table: options
 									})
-								}
-								<TableViewOverlay
-									layer={{
-										...TableViewLayer,
-										options: scene.table
-									}}
-									isTable={false}
-									active={activeLayerId === TableViewLayer.id}
-									onUpdate={(layer) => {
-										onUpdate({
-											...scene,
-											table: layer.options
-										})
-									}}
-									showBorder={true}
-									showGrid={true}
-								/>
-							</CurrentSceneContext.Provider>
+								}}
+								showBorder={true}
+								showGrid={true}
+							/>
 						</DraggableStage>
 					) : null}
 				</Box>
 			</ToolbarPortalProvider>
 
 			<LayerList
-				scene={scene}
+				layers={layers}
 				activeLayerId={activeLayerId}
 				setActiveLayer={setActiveLayerId}
 				updateLayer={updateLayer}

--- a/src/scene/canvas/index.tsx
+++ b/src/scene/canvas/index.tsx
@@ -12,7 +12,7 @@ import { deleteLayer } from '../layer';
 import LayerList from './layerList';
 import { ToolbarPortalProvider } from '../layer/toolbarPortal';
 import TableViewOverlay, { TableViewLayer } from '../layer/tableView';
-import { useTableResolution } from '../../settings';
+import { useTableDimensions } from '../../settings';
 
 export const CurrentSceneContext = React.createContext<IScene | null>(null);
 export function useCurrentScene() {
@@ -38,12 +38,30 @@ export function calculateViewportCenter(layerRef: React.MutableRefObject<Konva.L
 	}
 }
 
+export function calculateViewportDimensions(layerRef: React.MutableRefObject<Konva.Layer | undefined>) {
+	if (layerRef.current) {
+		const konvaStage = layerRef.current.parent!;
+		const stageSize = konvaStage.getSize();
+		const stageZoom = konvaStage.getAbsoluteScale();
+		return {
+			width: stageSize.width / stageZoom.x,
+			height: stageSize.height / stageZoom.y
+		};
+	}
+	else {
+		return {
+			width: 0,
+			height: 0
+		}
+	}
+}
+
 type Props = { scene: IScene, onUpdate: (scene: IScene) => void };
 const Canvas: React.SFC<Props> = ({ scene, onUpdate }) => {
 	const [activeLayerId, setActiveLayerId] = useState<string | null>(null);
 	const containerRef = useRef<HTMLDivElement>();
 	const containerSize = useComponentSize(containerRef);
-	const [tableResolution] = useTableResolution();
+	const tableDimensions = useTableDimensions();
 
 	// Default selected layer to the first layer
 	useEffect(() => {
@@ -124,10 +142,10 @@ const Canvas: React.SFC<Props> = ({ scene, onUpdate }) => {
 		}
 	}
 
-	const initialZoom = tableResolution ?
+	const initialZoom = tableDimensions ?
 		Math.min(
-			containerSize.height / tableResolution.height,
-			containerSize.width / tableResolution.width
+			containerSize.height / tableDimensions.height,
+			containerSize.width / tableDimensions.width
 		) :
 		1;
 
@@ -142,7 +160,7 @@ const Canvas: React.SFC<Props> = ({ scene, onUpdate }) => {
 						height: '100%'
 					}}
 				>
-					{containerSize.height !== 0 && tableResolution ? (
+					{containerSize.height !== 0 && tableDimensions ? (
 						<DraggableStage
 							width={containerSize.width || 1}
 							height={containerSize.height || 1}

--- a/src/scene/canvas/layerList.tsx
+++ b/src/scene/canvas/layerList.tsx
@@ -18,30 +18,29 @@ import VisibilityOffOutlinedIcon from '@mui/icons-material/VisibilityOffOutlined
 import ArrowUpwardOutlinedIcon from '@mui/icons-material/ArrowUpwardOutlined';
 import ArrowDownwardOutlinedIcon from '@mui/icons-material/ArrowDownwardOutlined';
 
-import { IScene } from "..";
 import { ILayer } from "../layer";
-import LayerType from "../layer/layerType";
-import { TableViewLayer } from "../layer/tableView";
 import EditLayerButton from "./editLayerButton";
 import DeleteLayerButton from "./deleteLayerButton";
 import AddLayerButton from "./addLayerButton";
 import theme from "../../theme";
+import * as Types from "../../protos/scene";
+import { TABLEVIEW_LAYER_ID } from "../layer/tableView";
 
 type Props = {
-	scene: IScene,
+	layers: Array<ILayer>,
 	activeLayerId: string | null,
-	setActiveLayer: (layer: string) => void,
+	setActiveLayer: (layerId: string) => void,
 	updateLayer: (layer: ILayer) => void,
-	addLayer: (type: LayerType) => void,
+	addLayer: (type: Types.Layer_LayerType) => void,
 	editActiveLayerName: (name: string) => void, // TODO
 	moveActiveLayer: (direction: "up" | "down") => void;
 	deleteActiveLayer: () => void
 };
-const LayerList: React.SFC<Props> = ({ scene, activeLayerId, setActiveLayer, addLayer, updateLayer, moveActiveLayer, deleteActiveLayer }) => {
-	const layerIndex = scene.layers.findIndex((l) => l.id === activeLayerId);
-	const isActiveLayerTop = layerIndex === scene.layers.length - 1;
+const LayerList: React.FunctionComponent<Props> = ({ layers, activeLayerId, setActiveLayer, addLayer, updateLayer, moveActiveLayer, deleteActiveLayer }) => {
+	const layerIndex = layers.findIndex((l) => l.id === activeLayerId);
+	const isActiveLayerTop = layerIndex === layers.length - 1;
 	const isActiveLayerBottom = layerIndex === 0;
-	const activeLayer = scene.layers.find((l) => l.id === activeLayerId);
+	const activeLayer = layers.find((l) => l.id === activeLayerId);
 
 	return (
 		<Card sx={{
@@ -52,18 +51,18 @@ const LayerList: React.SFC<Props> = ({ scene, activeLayerId, setActiveLayer, add
 		}}	>
 			<List dense={true}>
 				<ListItemButton
-					selected={activeLayerId === TableViewLayer.id}
-					onClick={() => setActiveLayer(TableViewLayer.id)}
+					selected={activeLayerId === TABLEVIEW_LAYER_ID}
+					onClick={() => setActiveLayer(TABLEVIEW_LAYER_ID)}
 				>
 					<ListItemIcon><IconButton size="small" disabled><TvOutlinedIcon /></IconButton></ListItemIcon>
-					<ListItemText primary={TableViewLayer.name} secondary=" " />
+					<ListItemText primary="TV/Table View" secondary=" " />
 				</ListItemButton>
 
-				{Array.from(scene.layers).reverse().map((layer) => (
+				{Array.from(layers).reverse().map((layer) => (
 					<ListItem
 						key={layer.id}
 						disablePadding
-						secondaryAction={<Typography color={theme.palette.text.disabled} variant="overline">{LayerType[layer.type]}</Typography>}
+						secondaryAction={<Typography color={theme.palette.text.disabled} variant="overline">{Types.Layer_LayerType[layer.type]}</Typography>}
 					>
 						<ListItemButton
 							selected={activeLayer === layer}
@@ -73,7 +72,8 @@ const LayerList: React.SFC<Props> = ({ scene, activeLayerId, setActiveLayer, add
 								<IconButton
 									size="small"
 									onClick={(e) => {
-										updateLayer({ ...layer, visible: !layer.visible })
+										layer.visible = !layer.visible;
+										updateLayer(layer)
 										e.stopPropagation() // to prevent the layer from becoming active
 									}}
 									disableRipple
@@ -96,7 +96,7 @@ const LayerList: React.SFC<Props> = ({ scene, activeLayerId, setActiveLayer, add
 				<Box>
 					{/* Move Layer Up */}
 					<IconButton
-						disabled={activeLayerId === null || activeLayerId === TableViewLayer.id || isActiveLayerTop}
+						disabled={activeLayerId === null || activeLayerId === TABLEVIEW_LAYER_ID || isActiveLayerTop}
 						onClick={() => moveActiveLayer('up')}
 						size="small"
 					>
@@ -108,7 +108,7 @@ const LayerList: React.SFC<Props> = ({ scene, activeLayerId, setActiveLayer, add
 
 					{/* Move Layer Down */}
 					<IconButton
-						disabled={activeLayerId === null || activeLayerId === TableViewLayer.id || isActiveLayerBottom}
+						disabled={activeLayerId === null || activeLayerId === TABLEVIEW_LAYER_ID || isActiveLayerBottom}
 						onClick={() => moveActiveLayer('down')}
 						size="small"
 					>
@@ -124,7 +124,7 @@ const LayerList: React.SFC<Props> = ({ scene, activeLayerId, setActiveLayer, add
 					/>
 				</Box>
 
-				<AddLayerButton onAdd={(type) => addLayer(type)} />
+				<AddLayerButton onAdd={addLayer} />
 			</CardActions>
 		</Card>
 	);

--- a/src/scene/canvas/transformableAsset.tsx
+++ b/src/scene/canvas/transformableAsset.tsx
@@ -1,13 +1,13 @@
 import React, { useRef, useEffect } from 'react';
 import { Group, Transformer } from 'react-konva';
 import Konva from 'konva';
-import theme from '../../theme';
 
-export type AssetTransform = Konva.RectConfig & { rotation: number };
+import theme from '../../theme';
+import * as Types from '../../protos/scene';
 
 type Props = {
-	rectTransform: AssetTransform,
-	onTransform: (newRect: AssetTransform) => void,
+	rectTransform: Types.AssetLayer_Asset_AssetTransform,
+	onTransform: (newRect: Types.AssetLayer_Asset_AssetTransform) => void,
 	isSelected: boolean,
 	onSelected: () => void,
 	snapOffset?: { x: number, y: number },

--- a/src/scene/canvas/transformableAsset.tsx
+++ b/src/scene/canvas/transformableAsset.tsx
@@ -1,7 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import { Group, Transformer } from 'react-konva';
 import Konva from 'konva';
-import { useTablePPI } from '../../settings';
 import theme from '../../theme';
 
 export type AssetTransform = Konva.RectConfig & { rotation: number };
@@ -26,7 +25,6 @@ const TransformableAsset: React.FunctionComponent<Props> = ({
 }) => {
 	const groupRef = useRef<Konva.Group>();
 	const trRef = useRef<Konva.Transformer>();
-	const ppi = useTablePPI();
 
 	useEffect(() => {
 		if (isSelected) {
@@ -66,11 +64,11 @@ const TransformableAsset: React.FunctionComponent<Props> = ({
 					let x = e.target.x();
 					let y = e.target.y();
 
-					if (snapOffset && ppi && rotation % 90 === 0) {
-						const xOffset = snapOffset.x % ppi;
-						const yOffset = snapOffset.y % ppi;
-						x = Math.round((x + xOffset) / ppi) * ppi - xOffset;
-						y = Math.round((y + yOffset) / ppi) * ppi - yOffset;
+					if (snapOffset && rotation % 90 === 0) {
+						const xOffset = snapOffset.x;
+						const yOffset = snapOffset.y;
+						x = Math.round((x + xOffset)) - xOffset;
+						y = Math.round((y + yOffset)) - yOffset;
 
 						e.target.x(x);
 						e.target.y(y);
@@ -111,6 +109,7 @@ const TransformableAsset: React.FunctionComponent<Props> = ({
 					enabledAnchors={skewEnabled === false ? ['top-left', 'top-right', 'bottom-left', 'bottom-right'] : undefined}
 					ref={trRef as any}
 					borderStrokeWidth={strokeEnabled === false ? 0 : undefined}
+					ignoreStroke={true}
 					anchorFill={theme.palette.primary.contrastText}
 					anchorStroke={theme.palette.primary.dark}
 					rotationSnaps={[0, 45, 90, 135, 180, 225, 270, 315]}

--- a/src/scene/editor.tsx
+++ b/src/scene/editor.tsx
@@ -1,4 +1,4 @@
-import React, { } from "react";
+import React, { useCallback } from "react";
 import { useMatch } from "react-router-dom";
 
 import Toolbar from '@mui/material/Toolbar';
@@ -56,7 +56,12 @@ function TableDisplayButton({ scene }: { scene: IScene }) {
 type Props = {};
 const SceneEditor: React.FunctionComponent<Props> = () => {
 	const match = useMatch('/scenes/:id');
-	const [scene, updateScene] = useOneValue(match!.params.id!);
+	const [scene, updateSceneLocal] = useOneValue(match!.params.id!);
+
+	const updateScene = useCallback((s: IScene) => {
+		s.version = scene!.version + 1;
+		updateSceneLocal(s)
+	}, [scene, updateSceneLocal])
 
 	if (!match?.params.id) {
 		return null;

--- a/src/scene/index.tsx
+++ b/src/scene/index.tsx
@@ -6,6 +6,8 @@ import LayerType from "./layer/layerType";
 import Konva from 'konva';
 import { IAssetLayer } from "./layer/assetLayer";
 import { deleteAsset } from "./asset";
+import { migrate, newSceneFromOldScene, oldSceneFromNewScene } from "./migrate";
+import { Scene } from "../protos/scene";
 
 export interface TableOptions {
 	displayGrid: boolean,
@@ -21,12 +23,54 @@ export interface IScene {
 	layers: Array<ILayer>;
 }
 
-const storage = globalStorage<IScene>('scene');
+export const oldStorage = globalStorage<IScene>('scene');
+export const newStorage = globalStorage<Uint8Array>('scene_2')
+
+
+
 export function sceneDatabase() {
 	return {
-		...storage,
+		...oldStorage,
+		useAllValues: () => {
+			const oldValues = oldStorage.useAllValues();
+			const newValues = newStorage.useAllValues();
+
+			if (oldValues === undefined || newValues === undefined) {
+				return undefined;
+			}
+
+			if (newValues.size < oldValues.size) {
+				migrate();
+				return undefined;
+			}
+
+			return new Map(
+				Array.from(newValues.entries())
+					.map(([sceneId, buf]) => [sceneId, oldSceneFromNewScene(Scene.decode(buf))])
+			)
+		},
+		useOneValue: (key: string): [IScene | null | undefined, (newData: IScene) => Promise<void>] => {
+			const [oldValue, setOldValue] = oldStorage.useOneValue(key);
+			const [newValue, setNewValue] = newStorage.useOneValue(key);
+
+			if (oldValue === undefined || newValue === undefined) {
+				return [oldValue, setOldValue];
+			}
+
+			if (newValue === undefined || newValue === null) {
+				migrate();
+				return [undefined, setOldValue];
+			}
+
+			return [oldSceneFromNewScene(Scene.decode(newValue)), async (scene) => {
+				await Promise.all([
+					// setOldValue(scene),
+					setNewValue(Scene.encode(newSceneFromOldScene(scene)).finish())
+				])
+			}]
+		},
 		deleteItem: async (key: string) => {
-			const scene = await storage.storage.getItem(key);
+			const scene = await oldStorage.storage.getItem(key);
 			for (const layer of scene.layers) {
 				if (layer.type !== LayerType.ASSETS) continue;
 
@@ -35,7 +79,7 @@ export function sceneDatabase() {
 				}
 			}
 
-			await storage.deleteItem(key);
+			await oldStorage.deleteItem(key);
 		}
 	};
 }

--- a/src/scene/index.tsx
+++ b/src/scene/index.tsx
@@ -19,6 +19,7 @@ export interface TableOptions {
 export interface IScene {
 	id: string;
 	name: string;
+	version: number;
 	table: TableOptions,
 	layers: Array<ILayer>;
 }
@@ -91,6 +92,7 @@ export function createNewScene(): IScene {
 	return {
 		id: v4(),
 		name: 'Untitled',
+		version: 0,
 		table: {
 			offset: { x: 0, y: 0 },
 			rotation: 0,

--- a/src/scene/index.tsx
+++ b/src/scene/index.tsx
@@ -87,6 +87,7 @@ export function sceneDatabase() {
 				}
 			}
 
+			await newStorage.deleteItem(key);
 			await oldStorage.deleteItem(key);
 		}
 	};

--- a/src/scene/layer/assetLayer/advancedAssetSizer.tsx
+++ b/src/scene/layer/assetLayer/advancedAssetSizer.tsx
@@ -7,13 +7,13 @@ import Tooltip from '@mui/material/Tooltip';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import LockOpenOutlinedIcon from '@mui/icons-material/LockOpenOutlined';
 
-import { IAssetCalibration } from '../../asset';
 import theme from '../../../theme';
 import InputWithUnit from '../../../partials/inputWithUnit';
 import InputGroup from '../../../partials/inputGroup';
+import * as Types from '../../../protos/scene';
 
-const AdvancedAssetSizer: React.FunctionComponent<{ calibration: IAssetCalibration; onUpdate: (calibration: IAssetCalibration) => void; }> = ({ calibration, onUpdate }) => {
-  function updateCalibrationValue(keys: Array<keyof IAssetCalibration>, e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
+const AdvancedAssetSizer: React.FunctionComponent<{ calibration: Types.AssetLayer_Asset_AssetCalibration; onUpdate: (calibration: Types.AssetLayer_Asset_AssetCalibration) => void; }> = ({ calibration, onUpdate }) => {
+  function updateCalibrationValue(keys: Array<keyof Types.AssetLayer_Asset_AssetCalibration>, e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
     const value = Number(e.target.value);
     if (!isNaN(value)) {
       const newCal = { ...calibration! };

--- a/src/scene/layer/assetLayer/asset.tsx
+++ b/src/scene/layer/assetLayer/asset.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect } from 'react';
 import { Image } from 'react-konva';
 
-import { IAsset, useAssetElement, AssetType } from '../../asset';
+import { useAssetElement } from '../../asset';
 import TransformableAsset from '../../canvas/transformableAsset';
+import * as Types from '../../../protos/scene';
 
 type Props = {
-	asset: IAsset;
-	onUpdate: (asset: IAsset) => void;
+	asset: Types.AssetLayer_Asset;
+	onUpdate: (asset: Types.AssetLayer_Asset) => void;
 	selected: boolean;
 	onSelected: () => void;
 	playAudio: boolean;
@@ -15,7 +16,7 @@ const Asset: React.FunctionComponent<Props> = ({ asset, onUpdate, selected, onSe
 	const el = useAssetElement(asset);
 
 	useEffect(() => {
-		if (asset.type === AssetType.VIDEO && el) {
+		if (asset.type === Types.AssetLayer_Asset_AssetType.VIDEO && el) {
 			(el as HTMLVideoElement).muted = !playAudio;
 			return () => {
 				(el as HTMLVideoElement).muted = true;
@@ -24,14 +25,14 @@ const Asset: React.FunctionComponent<Props> = ({ asset, onUpdate, selected, onSe
 		return () => {}
 	}, [asset, playAudio, el])
 
-	const xOffset = asset.calibration ? (asset.calibration.xOffset * (asset.transform.width ?? 0 / asset.size.width)) : 0;
-	const yOffset = asset.calibration ? (asset.calibration.yOffset * (asset.transform.height ?? 0 / asset.size.height)) : 0;
+	const xOffset = asset.calibration ? (asset.calibration.xOffset / asset.calibration.ppiX) : 0;
+	const yOffset = asset.calibration ? (asset.calibration.yOffset / asset.calibration.ppiY) : 0;
 
 	return (
 		<TransformableAsset
 			isSelected={selected}
 			onSelected={onSelected}
-			rectTransform={asset.transform}
+			rectTransform={asset.transform!}
 			snapOffset={asset.snapToGrid ? { x: xOffset, y: yOffset } : undefined}
 			onTransform={(newRect) => {
 				onUpdate({
@@ -41,8 +42,8 @@ const Asset: React.FunctionComponent<Props> = ({ asset, onUpdate, selected, onSe
 			}}>
 			{el && <Image
 				image={el}
-				width={asset.transform.width}
-				height={asset.transform.height}
+				width={asset.transform!.width}
+				height={asset.transform!.height}
 			/>}
 		</TransformableAsset>
 	);

--- a/src/scene/layer/assetLayer/asset.tsx
+++ b/src/scene/layer/assetLayer/asset.tsx
@@ -11,7 +11,7 @@ type Props = {
 	onSelected: () => void;
 	playAudio: boolean;
 };
-const Asset: React.SFC<Props> = ({ asset, onUpdate, selected, onSelected, playAudio }) => {
+const Asset: React.FunctionComponent<Props> = ({ asset, onUpdate, selected, onSelected, playAudio }) => {
 	const el = useAssetElement(asset);
 
 	useEffect(() => {

--- a/src/scene/layer/assetLayer/assetSizer.tsx
+++ b/src/scene/layer/assetLayer/assetSizer.tsx
@@ -16,15 +16,15 @@ import { AssetTransform } from '../../canvas/transformableAsset';
 import VisualAssetSizer from './visualAssetSizer';
 import { VISUAL_ASSET_SIZER_SIZE } from '../../../theme';
 
-export function calculateCalibratedTransform(asset: IAsset, screenPPI: number): AssetTransform {
+export function calculateCalibratedTransform(asset: IAsset): AssetTransform {
   if (!asset.calibration) {
     return asset.transform;
   }
 
   return {
     ...asset.transform,
-    width: (asset.size.width / asset.calibration.ppiX) * screenPPI,
-    height: (asset.size.height / asset.calibration.ppiY) * screenPPI
+    width: (asset.size.width / asset.calibration.ppiX),
+    height: (asset.size.height / asset.calibration.ppiY)
   }
 }
 

--- a/src/scene/layer/assetLayer/assetSizer.tsx
+++ b/src/scene/layer/assetLayer/assetSizer.tsx
@@ -9,33 +9,32 @@ import Button from '@mui/material/Button';
 
 import AspectRatioOutlinedIcon from '@mui/icons-material/AspectRatioOutlined';
 
-import { IAsset, IAssetCalibration } from '../../asset';
 import ToolbarItem from '../toolbarItem';
 import AdvancedAssetSizer from './advancedAssetSizer';
-import { AssetTransform } from '../../canvas/transformableAsset';
 import VisualAssetSizer from './visualAssetSizer';
 import { VISUAL_ASSET_SIZER_SIZE } from '../../../theme';
+import * as Types from '../../../protos/scene';
 
-export function calculateCalibratedTransform(asset: IAsset): AssetTransform {
+export function calculateCalibratedTransform(asset: Types.AssetLayer_Asset): Types.AssetLayer_Asset_AssetTransform {
   if (!asset.calibration) {
-    return asset.transform;
+    return asset.transform!;
   }
 
   return {
-    ...asset.transform,
-    width: (asset.size.width / asset.calibration.ppiX),
-    height: (asset.size.height / asset.calibration.ppiY)
+    ...asset.transform!,
+    width: (asset.size!.width / asset.calibration.ppiX),
+    height: (asset.size!.height / asset.calibration.ppiY)
   }
 }
 
 type Props = {
-  asset?: IAsset,
-  onUpdate: (asset: IAsset) => void
+  asset?: Types.AssetLayer_Asset,
+  onUpdate: (asset: Types.AssetLayer_Asset) => void
 };
 
 const AssetSizer: React.SFC<Props> = ({ asset, onUpdate }) => {
   const [showModal, setShowModal] = useState(false);
-  const [calibration, setCalibration] = useState<IAssetCalibration>();
+  const [calibration, setCalibration] = useState<Types.AssetLayer_Asset_AssetCalibration>();
 
   useEffect(() => {
     if (asset) {

--- a/src/scene/layer/assetLayer/visualAssetSizer.tsx
+++ b/src/scene/layer/assetLayer/visualAssetSizer.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import { Layer, Rect } from 'react-konva';
 import Konva from 'konva';
 
-import { IAssetCalibration, IAsset } from '../../asset';
 import DraggableStage from '../../canvas/draggableStage';
 import Asset from './asset';
 import theme, { VISUAL_ASSET_SIZER_SIZE } from '../../../theme';
 import TransformableAsset from '../../canvas/transformableAsset';
+import * as Types from '../../../protos/scene';
 
 const RESIZE_SQUARES = 3;
 
-const VisualAssetSizer: React.FunctionComponent<{ asset: IAsset; onUpdate: (calibration: IAssetCalibration) => void; }> = ({ asset, onUpdate }) => {
+const VisualAssetSizer: React.FunctionComponent<{ asset: Types.AssetLayer_Asset; onUpdate: (calibration: Types.AssetLayer_Asset_AssetCalibration) => void; }> = ({ asset, onUpdate }) => {
   if (!asset.calibration) {
     return null;
   }
@@ -38,14 +38,14 @@ const VisualAssetSizer: React.FunctionComponent<{ asset: IAsset; onUpdate: (cali
       sx={{
         marginLeft: `-1.5rem`
       }}
-      initialZoom={(VISUAL_ASSET_SIZER_SIZE / asset.size.width)}
+      initialZoom={(VISUAL_ASSET_SIZER_SIZE / asset.size!.width)}
     >
       <Layer>
         <Asset
           asset={{
             ...asset,
             transform: {
-              ...asset.size,
+              ...asset.size!,
               rotation: 0,
               x: 0,
               y: 0

--- a/src/scene/layer/assetLayer/visualAssetSizer.tsx
+++ b/src/scene/layer/assetLayer/visualAssetSizer.tsx
@@ -6,15 +6,12 @@ import { IAssetCalibration, IAsset } from '../../asset';
 import DraggableStage from '../../canvas/draggableStage';
 import Asset from './asset';
 import theme, { VISUAL_ASSET_SIZER_SIZE } from '../../../theme';
-import { useTablePPI } from '../../../settings';
 import TransformableAsset from '../../canvas/transformableAsset';
 
 const RESIZE_SQUARES = 3;
 
-const VisualAssetSizer: React.SFC<{ asset: IAsset; onUpdate: (calibration: IAssetCalibration) => void; }> = ({ asset, onUpdate }) => {
-  const tablePPI = useTablePPI();
-
-  if (!tablePPI || !asset.calibration) {
+const VisualAssetSizer: React.FunctionComponent<{ asset: IAsset; onUpdate: (calibration: IAssetCalibration) => void; }> = ({ asset, onUpdate }) => {
+  if (!asset.calibration) {
     return null;
   }
 

--- a/src/scene/layer/fogLayer/editLightToolbarItem.tsx
+++ b/src/scene/layer/fogLayer/editLightToolbarItem.tsx
@@ -10,11 +10,11 @@ import Button from "@mui/material/Button";
 
 import BrightnessMediumOutlinedIcon from '@mui/icons-material/BrightnessMediumOutlined';
 
-import { ILightSource } from './rayCastRevealPolygon';
 import ToolbarItem from '../toolbarItem';
 import InputGroup from '../../../partials/inputGroup';
 import InputWithUnit from '../../../partials/inputWithUnit';
 import theme from '../../../theme';
+import * as Types from '../../../protos/scene';
 
 const DEFAULT_LIGHT_SOURCES = [
   {
@@ -42,12 +42,12 @@ const DEFAULT_LIGHT_SOURCES = [
     brightLightDistance: 60 / 5,
     dimLightDistance: 120 / 5
   },
-] as Array<Partial<ILightSource> & { name: string }>;
+] as Array<Partial<Types.FogLayer_LightSource> & { name: string }>;
 
-type Props = { light: ILightSource | null, onUpdate: (light: ILightSource) => void };
+type Props = { light: Types.FogLayer_LightSource | null, onUpdate: (light: Types.FogLayer_LightSource) => void };
 const EditLightToolbarItem: React.FunctionComponent<Props> = ({ light, onUpdate }) => {
   const [showModal, setShowModal] = useState(false);
-  const [localLight, setLocalLight] = useState<ILightSource | null>(light);
+  const [localLight, setLocalLight] = useState<Types.FogLayer_LightSource | null>(light);
 
   useEffect(() => {
     setLocalLight(light);
@@ -106,8 +106,8 @@ const EditLightToolbarItem: React.FunctionComponent<Props> = ({ light, onUpdate 
                   onClick={() => {
                     setLocalLight({
                       ...localLight,
-                      brightLightDistance: lightSource.brightLightDistance,
-                      dimLightDistance: lightSource.dimLightDistance
+                      brightLightDistance: lightSource.brightLightDistance!,
+                      dimLightDistance: lightSource.dimLightDistance!
                     });
                   }}
                 >

--- a/src/scene/layer/fogLayer/editablePolygon.tsx
+++ b/src/scene/layer/fogLayer/editablePolygon.tsx
@@ -2,8 +2,9 @@ import React, { useRef, useEffect, useState } from 'react';
 import { KonvaNodeEvents, Line, Group, Shape } from 'react-konva';
 import Konva from 'konva';
 
-import { useKeyPress } from '../../utils';
-import theme from '../../theme';
+import { useKeyPress } from '../../../utils';
+import theme from '../../../theme';
+import * as Types from '../../../protos/scene';
 
 const ANCHOR_RADIUS = 7;
 const Anchor: React.FunctionComponent<{
@@ -52,21 +53,9 @@ const Anchor: React.FunctionComponent<{
   )
 }
 
-export enum PolygonType {
-  FOG,
-  FOG_CLEAR,
-  LIGHT_OBSTRUCTION
-}
-
-export interface IPolygon {
-  type: PolygonType,
-  verticies: Array<Konva.Vector2d>
-  visibleOnTable: boolean;
-}
-
 interface Props {
-  polygon: IPolygon
-  onUpdate: (polygon: IPolygon) => void
+  polygon: Types.FogLayer_Polygon
+  onUpdate: (polygon: Types.FogLayer_Polygon) => void
 
   adding: boolean
   onAdded?: () => void

--- a/src/scene/layer/fogLayer/rayCastRevealPolygon.tsx
+++ b/src/scene/layer/fogLayer/rayCastRevealPolygon.tsx
@@ -1,27 +1,22 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
 import { Shape, Line } from 'react-konva';
 import Konva from 'konva';
 
 import { yellow } from '@mui/material/colors';
 
-import { IPolygon, PolygonType } from "../editablePolygon";
 import { getVisibilityPolygon } from './rayCastingUtils';
 import theme from '../../../theme';
+import * as Types from '../../../protos/scene';
 
-export interface ILightSource {
-  position: Konva.Vector2d,
-  brightLightDistance?: number,
-  dimLightDistance?: number,
-}
 
-export function defaultLightSource(light: ILightSource) {
-  // torch light
+export function defaultLightSource(light: Partial<Types.FogLayer_LightSource>) {
+  // default to torch light
   light.brightLightDistance = light.brightLightDistance === undefined ? 4 : light.brightLightDistance;
   light.dimLightDistance = light.dimLightDistance === undefined ? 8 : light.dimLightDistance;
-  return light;
+  return light as Types.FogLayer_LightSource;
 }
 
-function useFogBoundsPolygon(lightSource: Konva.Vector2d, fogPolygons: Array<IPolygon>): IPolygon {
+function calculateBoundsPolygon(lightSource: Konva.Vector2d, fogPolygons: Array<Types.FogLayer_Polygon>): Types.FogLayer_Polygon {
   let minX: number = lightSource.x;
   let maxX: number = lightSource.x;
   let minY: number = lightSource.y;
@@ -45,7 +40,7 @@ function useFogBoundsPolygon(lightSource: Konva.Vector2d, fogPolygons: Array<IPo
   maxY += 10;
 
   return {
-    type: PolygonType.LIGHT_OBSTRUCTION,
+    type: Types.FogLayer_Polygon_PolygonType.LIGHT_OBSTRUCTION,
     verticies: [
       { x: minX, y: minY }, // top left
       { x: maxX, y: minY }, // top right
@@ -60,11 +55,11 @@ function useFogBoundsPolygon(lightSource: Konva.Vector2d, fogPolygons: Array<IPo
 // const fillGradientColorStops = [0, 'rgba(255,255,255,0.90)', 0.10, 'rgba(255,255,255,0.70)', 0.40, 'rgba(255,255,255,0.40)', 0.60, 'rgba(255,255,255,0.10)', 1, 'transparent'];
 
 type Props = {
-  light: ILightSource,
+  light: Types.FogLayer_LightSource,
   displayIcon: boolean,
-  obstructionPolygons: Array<IPolygon>,
-  fogPolygons: Array<IPolygon>
-  onUpdate: (light: ILightSource) => void,
+  obstructionPolygons: Array<Types.FogLayer_Polygon>,
+  fogPolygons: Array<Types.FogLayer_Polygon>
+  onUpdate: (light: Types.FogLayer_LightSource) => void,
   isTable: boolean,
   selected: boolean,
   onSelected: () => void
@@ -72,17 +67,21 @@ type Props = {
 const RayCastRevealPolygon: React.FunctionComponent<Props> = ({ light, displayIcon, fogPolygons, obstructionPolygons, onUpdate, selected, onSelected }) => {
   const iconRef = useRef<Konva.Shape>();
 
-  const [localPosition, setLocalPosition] = useState(light.position);
+  const [localPosition, setLocalPosition] = useState(light.position!);
 
+  const positionX = light.position!.x;
+  const positionY = light.position!.y;
   useEffect(() => {
-    setLocalPosition(light.position);
-  }, [light.position, setLocalPosition])
+    setLocalPosition({ x: positionX, y: positionY });
+  }, [positionX, positionY])
 
-  let fogPolygon = useFogBoundsPolygon(localPosition, fogPolygons);
   const defaultedLight = defaultLightSource(light);
-
-  const obstructionWithFogPoly = [...obstructionPolygons.filter((p) => p.visibleOnTable), fogPolygon];
-  const visibilityPolygon = getVisibilityPolygon(localPosition, obstructionWithFogPoly);
+  
+  const visibilityPolygon = useMemo(() => {
+    let fogPolygon = calculateBoundsPolygon(localPosition, fogPolygons);
+    const obstructionWithFogPoly = [...obstructionPolygons.filter((p) => p.visibleOnTable), fogPolygon];
+    return getVisibilityPolygon(localPosition, obstructionWithFogPoly)
+  }, [localPosition, obstructionPolygons, fogPolygons]);
 
   const visibilityLinePoints = visibilityPolygon.verticies
     .map((v) => [v.x, v.y]).flat();
@@ -118,8 +117,8 @@ const RayCastRevealPolygon: React.FunctionComponent<Props> = ({ light, displayIc
       {displayIcon && (
         <Shape
           name={"Icon"}
-          x={light.position.x}
-          y={light.position.y}
+          x={light.position!.x}
+          y={light.position!.y}
           ref={iconRef as any}
           onMouseDown={(e) => {
             if (e.evt.button === 0 && selected) {
@@ -143,7 +142,8 @@ const RayCastRevealPolygon: React.FunctionComponent<Props> = ({ light, displayIc
             })
           }}
           onDragEnd={e => {
-            light.position = { x: e.target.x(), y: e.target.y() };
+            light.position!.x = e.target.x();
+            light.position!.y = e.target.y();
             onUpdate(light);
           }}
           onClick={(e) => {

--- a/src/scene/layer/fogLayer/rayCastRevealPolygon.tsx
+++ b/src/scene/layer/fogLayer/rayCastRevealPolygon.tsx
@@ -6,7 +6,6 @@ import { yellow } from '@mui/material/colors';
 
 import { IPolygon, PolygonType } from "../editablePolygon";
 import { getVisibilityPolygon } from './rayCastingUtils';
-import { useTablePPI } from '../../../settings';
 import theme from '../../../theme';
 
 export interface ILightSource {
@@ -71,7 +70,6 @@ type Props = {
   onSelected: () => void
 };
 const RayCastRevealPolygon: React.FunctionComponent<Props> = ({ light, displayIcon, fogPolygons, obstructionPolygons, onUpdate, selected, onSelected }) => {
-  const ppi = useTablePPI() || 86;
   const iconRef = useRef<Konva.Shape>();
 
   const [localPosition, setLocalPosition] = useState(light.position);
@@ -109,7 +107,7 @@ const RayCastRevealPolygon: React.FunctionComponent<Props> = ({ light, displayIc
         fillRadialGradientStartPoint={localPosition}
         fillRadialGradientEndPoint={localPosition}
         fillRadialGradientStartRadius={0}
-        fillRadialGradientEndRadius={ppi * Math.max(defaultedLight.brightLightDistance!, defaultedLight.dimLightDistance!)}
+        fillRadialGradientEndRadius={Math.max(defaultedLight.brightLightDistance!, defaultedLight.dimLightDistance!)}
         fillRadialGradientColorStops={[
           0, 'rgba(255,255,255,1)',
           dimlightBrightLightRatio, 'rgba(255,255,255,0.30)',

--- a/src/scene/layer/fogLayer/rayCastingUtils.tsx
+++ b/src/scene/layer/fogLayer/rayCastingUtils.tsx
@@ -1,5 +1,6 @@
 import Konva from 'konva';
-import { IPolygon, PolygonType } from "../editablePolygon";
+
+import * as Types from '../../../protos/scene';
 
 type Segment = {
   a: Konva.Vector2d,
@@ -56,7 +57,7 @@ export function getIntersection(ray: Segment, segment: Segment): Intersection | 
   };
 }
 
-export function getVisibilityPolygon(position: Konva.Vector2d, polygons: Array<IPolygon>): IPolygon {
+export function getVisibilityPolygon(position: Konva.Vector2d, polygons: Array<Types.FogLayer_Polygon>): Types.FogLayer_Polygon {
   // Get all unique points
   const points = new Array<Konva.Vector2d & { angle?: number }>();
   const segments = new Array<Segment>();
@@ -121,7 +122,7 @@ export function getVisibilityPolygon(position: Konva.Vector2d, polygons: Array<I
 
   // Sort intersects by angle
   return {
-    type: PolygonType.FOG_CLEAR, // TODO: change
+    type: Types.FogLayer_Polygon_PolygonType.FOG_CLEAR, // TODO: change
     visibleOnTable: true,
     verticies: intersects.sort(function (a, b) {
       return a.angle! - b.angle!;

--- a/src/scene/layer/layerType.tsx
+++ b/src/scene/layer/layerType.tsx
@@ -1,8 +1,0 @@
-
-enum LayerType {
-	ASSETS,
-	FOG,
-	TABLE_VIEW
-}
-
-export default LayerType;

--- a/src/scene/layer/tableView/index.tsx
+++ b/src/scene/layer/tableView/index.tsx
@@ -9,38 +9,29 @@ import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import VisibilityOffOutlinedIcon from '@mui/icons-material/VisibilityOffOutlined';
 
 import { useTableDimensions } from '../../../settings';
-import { TableOptions } from '../..';
-import { ILayerComponentProps, ILayer } from '..';
-import LayerType from "../layerType";
 import ToolbarItem from '../toolbarItem';
 import ToolbarPortal from '../toolbarPortal';
 import ZoomToolbarItem from './zoomToolbarItem';
 import theme from '../../../theme';
+import * as Types from "../../../protos/scene";
 
-export const TableViewLayer = {
-  id: 'TABLE_VIEW',
-  name: 'TV/Table View',
-  type: LayerType.TABLE_VIEW,
-  visible: true
-} as ILayer;
+export const TABLEVIEW_LAYER_ID = 'TABLE_VIEW';
 
-export interface ITableViewLayer extends ILayer {
-  options: TableOptions
-}
-
-interface Props extends ILayerComponentProps<ITableViewLayer> {
+type Props = {
+  options: Types.TableOptions,
+  active: boolean;
   showBorder: boolean;
   showGrid: boolean;
+  onUpdate: (options: Types.TableOptions) => void
 }
-
-const TableViewOverlay: React.FunctionComponent<Props> = ({ layer, active, showBorder, showGrid, onUpdate }) => {
+const TableViewOverlay: React.FunctionComponent<Props> = ({ options, active, showBorder, showGrid, onUpdate }) => {
   const tableDimensions = useTableDimensions();
 
-  const [localOptions, setLocalOptions] = useState(layer.options);
+  const [localOptions, setLocalOptions] = useState(options);
 
   useEffect(() => {
-    setLocalOptions(layer.options);
-  }, [layer.options])
+    setLocalOptions(options);
+  }, [options])
 
   const groupRef = useRef<Konva.Group>();
   const trRef = useRef<Konva.Transformer>();
@@ -61,42 +52,35 @@ const TableViewOverlay: React.FunctionComponent<Props> = ({ layer, active, showB
           label="Reset View"
           onClick={() => {
             onUpdate({
-              ...layer,
-              options: {
-                ...layer.options,
-                offset: { x: 0, y: 0 },
-                rotation: 0,
-                scale: 1
-              }
+              ...options,
+              offset: { x: 0, y: 0 },
+              rotation: 0,
+              scale: 1
             })
           }}
         />
         <ToolbarItem
-          label={layer.options.displayGrid ? 'Hide Grid' : 'Show Grid'}
-          icon={layer.options.displayGrid ? <VisibilityOffOutlinedIcon /> : <VisibilityOutlinedIcon />}
+          label={options.displayGrid ? 'Hide Grid' : 'Show Grid'}
+          icon={options.displayGrid ? <VisibilityOffOutlinedIcon /> : <VisibilityOutlinedIcon />}
           onClick={() => {
             onUpdate({
-              ...layer,
-              options: {
-                ...layer.options,
-                displayGrid: !layer.options.displayGrid
-              }
+              ...options,
+              displayGrid: !options.displayGrid
             })
           }}
         />
         <ZoomToolbarItem
-          zoom={layer.options.scale}
+          zoom={options.scale}
           onUpdate={(zoom) => {
-            layer.options = {
-              ...layer.options,
+            onUpdate({
+              ...options,
               scale: zoom
-            }
-            onUpdate(layer);
+            });
           }}
         />
       </>
     );
-  }, [layer, onUpdate]);
+  }, [options, onUpdate]);
 
   // Only recalculate the line components when the position/size changes
   const lines = useMemo(() => {
@@ -106,22 +90,23 @@ const TableViewOverlay: React.FunctionComponent<Props> = ({ layer, active, showB
 
     const width = tableDimensions.width / localOptions.scale;
     const height = tableDimensions.height / localOptions.scale;
+    const offset = localOptions.offset!;
 
     const l = new Array<{ start: Konva.Vector2d; end: Konva.Vector2d; }>();
     if (showGrid) {
-      const startX = Math.floor(localOptions.offset.x);
-      for (let xOffset = startX; xOffset <= localOptions.offset.x + width; xOffset++) {
+      const startX = Math.floor(offset.x);
+      for (let xOffset = startX; xOffset <= offset.x + width; xOffset++) {
         l.push({
-          start: { x: xOffset, y: localOptions.offset.y },
-          end: { x: xOffset, y: localOptions.offset.y + height }
+          start: { x: xOffset, y: offset.y },
+          end: { x: xOffset, y: offset.y + height }
         });
       }
 
-      const startY = Math.floor(localOptions.offset.y);
-      for (let yOffset = startY; yOffset <= localOptions.offset.y + height; yOffset++) {
+      const startY = Math.floor(offset.y);
+      for (let yOffset = startY; yOffset <= offset.y + height; yOffset++) {
         l.push({
-          start: { x: localOptions.offset.x, y: yOffset },
-          end: { x: localOptions.offset.x + width, y: yOffset }
+          start: { x: offset.x, y: yOffset },
+          end: { x: offset.x + width, y: yOffset }
         });
       }
     }
@@ -130,11 +115,11 @@ const TableViewOverlay: React.FunctionComponent<Props> = ({ layer, active, showB
       <Group
         clipFunc={(ctx: CanvasRenderingContext2D) => {
           ctx.beginPath();
-          ctx.rect(localOptions.offset.x, localOptions.offset.y, width, height);
+          ctx.rect(offset.x, offset.y, width, height);
           ctx.rotate(localOptions.rotation);
           ctx.closePath();
         }}
-        opacity={localOptions.displayGrid ? 1 : (active ? 0.5 : 0)}
+        opacity={localOptions.displayGrid ? (active ? 1 : 0.75) : (active ? 0.5 : 0)}
       >
         {l.map((line, i) => (
           <React.Fragment key={i}>
@@ -178,8 +163,8 @@ const TableViewOverlay: React.FunctionComponent<Props> = ({ layer, active, showB
         <>
           <Group
             ref={groupRef as any}
-            x={localOptions.offset.x}
-            y={localOptions.offset.y}
+            x={localOptions.offset?.x ?? 0}
+            y={localOptions.offset?.y ?? 0}
             width={width}
             height={height}
             scaleX={1 / localOptions.scale}
@@ -205,8 +190,9 @@ const TableViewOverlay: React.FunctionComponent<Props> = ({ layer, active, showB
               });
             }}
             onDragEnd={() => {
-              layer.options = { ...localOptions };
-              onUpdate(layer)
+              onUpdate({
+                ...localOptions
+              })
             }}
             onTransform={() => {
               const node = groupRef.current!;
@@ -221,8 +207,7 @@ const TableViewOverlay: React.FunctionComponent<Props> = ({ layer, active, showB
               });
             }}
             onTransformEnd={() => {
-              layer.options = { ...localOptions };
-              onUpdate(layer);
+              onUpdate({ ...localOptions });
             }}
           >
             <Rect

--- a/src/scene/layer/tableView/index.tsx
+++ b/src/scene/layer/tableView/index.tsx
@@ -8,7 +8,7 @@ import AnchorOutlinedIcon from '@mui/icons-material/AnchorOutlined';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import VisibilityOffOutlinedIcon from '@mui/icons-material/VisibilityOffOutlined';
 
-import { useTableResolution, useTablePPI } from '../../../settings';
+import { useTableDimensions } from '../../../settings';
 import { TableOptions } from '../..';
 import { ILayerComponentProps, ILayer } from '..';
 import LayerType from "../layerType";
@@ -34,14 +34,13 @@ interface Props extends ILayerComponentProps<ITableViewLayer> {
 }
 
 const TableViewOverlay: React.FunctionComponent<Props> = ({ layer, active, showBorder, showGrid, onUpdate }) => {
-  const [tableResolution] = useTableResolution();
-  const ppi = useTablePPI();
+  const tableDimensions = useTableDimensions();
 
   const [localOptions, setLocalOptions] = useState(layer.options);
 
   useEffect(() => {
     setLocalOptions(layer.options);
-  }, [layer.options, setLocalOptions])
+  }, [layer.options])
 
   const groupRef = useRef<Konva.Group>();
   const trRef = useRef<Konva.Transformer>();
@@ -101,25 +100,25 @@ const TableViewOverlay: React.FunctionComponent<Props> = ({ layer, active, showB
 
   // Only recalculate the line components when the position/size changes
   const lines = useMemo(() => {
-    if (!tableResolution || !ppi) {
+    if (!tableDimensions) {
       return null;
     }
 
-    const width = tableResolution.width / localOptions.scale;
-    const height = tableResolution.height / localOptions.scale;
+    const width = tableDimensions.width / localOptions.scale;
+    const height = tableDimensions.height / localOptions.scale;
 
     const l = new Array<{ start: Konva.Vector2d; end: Konva.Vector2d; }>();
     if (showGrid) {
-      const startX = Math.floor(localOptions.offset.x / ppi) * ppi;
-      for (let xOffset = startX; xOffset <= localOptions.offset.x + width; xOffset += ppi) {
+      const startX = Math.floor(localOptions.offset.x);
+      for (let xOffset = startX; xOffset <= localOptions.offset.x + width; xOffset++) {
         l.push({
           start: { x: xOffset, y: localOptions.offset.y },
           end: { x: xOffset, y: localOptions.offset.y + height }
         });
       }
 
-      const startY = Math.floor(localOptions.offset.y / ppi) * ppi;
-      for (let yOffset = startY; yOffset <= localOptions.offset.y + height; yOffset += ppi) {
+      const startY = Math.floor(localOptions.offset.y);
+      for (let yOffset = startY; yOffset <= localOptions.offset.y + height; yOffset++) {
         l.push({
           start: { x: localOptions.offset.x, y: yOffset },
           end: { x: localOptions.offset.x + width, y: yOffset }
@@ -160,14 +159,14 @@ const TableViewOverlay: React.FunctionComponent<Props> = ({ layer, active, showB
         ))}
       </Group>
     );
-  }, [showGrid, localOptions, active, tableResolution, ppi])
+  }, [showGrid, localOptions, active, tableDimensions])
 
-  if (!tableResolution || ppi === null) {
+  if (!tableDimensions) {
     return null;
   }
 
-  const width = tableResolution.width;
-  const height = tableResolution.height;
+  const width = tableDimensions.width;
+  const height = tableDimensions.height;
 
   return (
     <Layer
@@ -231,7 +230,8 @@ const TableViewOverlay: React.FunctionComponent<Props> = ({ layer, active, showB
               height={height}
               stroke={active ? theme.palette.primary.dark : grey[300]}
               dash={[10, 10]}
-              strokeWidth={5}
+              strokeWidth={3}
+              strokeScaleEnabled={false}
               listening={active}
             />
           </Group>
@@ -242,6 +242,7 @@ const TableViewOverlay: React.FunctionComponent<Props> = ({ layer, active, showB
               enabledAnchors={['top-left', 'top-right', 'bottom-left', 'bottom-right']}
               ref={trRef as any}
               borderStrokeWidth={0}
+              ignoreStroke={true}
               anchorFill={theme.palette.primary.contrastText}
               anchorStroke={theme.palette.primary.dark}
             />

--- a/src/scene/list.tsx
+++ b/src/scene/list.tsx
@@ -41,8 +41,9 @@ const SceneList: React.FunctionComponent<Props> = ({ onSceneSelect, selectedScen
     if (allScenes) {
       scene.name = `Scene ${allScenes.size + 1}`;
     }
-    createItem(scene.id, scene);
-    onSceneSelect(scene);
+    createItem(scene.id, scene).then(() => {
+      onSceneSelect(scene);
+    });
   }
 
   if (allScenes === undefined) {

--- a/src/scene/list.tsx
+++ b/src/scene/list.tsx
@@ -12,7 +12,8 @@ import IconButton from '@mui/material/IconButton'
 
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 
-import { IScene, sceneDatabase, createNewScene } from ".";
+import { sceneDatabase, createNewScene } from ".";
+import * as Types from '../protos/scene';
 
 import { SceneListItem } from "./listItem";
 
@@ -30,9 +31,7 @@ function LoadingScenes() {
   );
 }
 
-export
-
-  type Props = { onSceneSelect: (scene: IScene) => any, selectedSceneId: string };
+type Props = { onSceneSelect: (scene: Types.Scene) => any, selectedSceneId: string };
 const SceneList: React.FunctionComponent<Props> = ({ onSceneSelect, selectedSceneId }) => {
   const allScenes = useAllValues();
   const [searchText, setSearchText] = useState("");

--- a/src/scene/listItem.tsx
+++ b/src/scene/listItem.tsx
@@ -17,15 +17,16 @@ import MoreVertIcon from '@mui/icons-material/MoreVert';
 import DriveFileRenameOutlineOutlinedIcon from '@mui/icons-material/DriveFileRenameOutlineOutlined';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 
-import { IScene, sceneDatabase } from ".";
+import { sceneDatabase } from ".";
 import { settingsDatabase, Settings } from "../settings";
 import ConfirmDialog from "../partials/confirmDialog";
 import RenameDialog from "../partials/renameDialog";
+import * as Types from '../protos/scene';
 
 const { deleteItem, useOneValue } = sceneDatabase();
 const { useOneValue: useOneSettingValue } = settingsDatabase();
 
-const SceneStatusIcon: React.FunctionComponent<{ scene: IScene }> = ({ scene }) => {
+const SceneStatusIcon: React.FunctionComponent<{ scene: Types.Scene }> = ({ scene }) => {
   const [displayedScene] = useOneSettingValue(Settings.DISPLAYED_SCENE);
   const [tableFreeze] = useOneSettingValue(Settings.TABLE_FREEZE);
 
@@ -42,7 +43,7 @@ const SceneStatusIcon: React.FunctionComponent<{ scene: IScene }> = ({ scene }) 
   }
 }
 
-export const SceneListItem: React.FunctionComponent<{ scene: IScene; selected: boolean; onSelect: () => void; }> = ({ scene, selected, onSelect }) => {
+export const SceneListItem: React.FunctionComponent<{ scene: Types.Scene; selected: boolean; onSelect: () => void; }> = ({ scene, selected, onSelect }) => {
   const navigate = useNavigate();
 
   const anchorEl = useRef<HTMLElement>();
@@ -98,9 +99,9 @@ export const SceneListItem: React.FunctionComponent<{ scene: IScene; selected: b
         open={inEdit}
         name={scene.name}
         onConfirm={(name) => {
-          updateScene({ ...scene, name }).then(() => {
-            setInEdit(false);
-          })
+          scene.name = name;
+          updateScene(scene);
+          setInEdit(false);
         }}
         onCancel={() => setInEdit(false)}
       />

--- a/src/scene/menu.tsx
+++ b/src/scene/menu.tsx
@@ -10,10 +10,10 @@ import Modal from '@mui/material/Modal'
 import Link from '@mui/material/Link'
 
 import theme from '../theme';
-import { IScene } from '.';
 import SceneList from './list';
 import FloatingIcon from '../partials/floatingIcon';
 import SettingsPanel from '../settings';
+import * as Types from '../protos/scene';
 
 enum TabOptions {
 	SCENES,
@@ -35,7 +35,7 @@ const Menu: React.FunctionComponent<Props> = () => {
 
 	const currentSelectedSceneId = useCurrentSelectedSceneId();
 
-	function onSceneSelect(scene: IScene) {
+	function onSceneSelect(scene: Types.Scene) {
 		navigate(`/scenes/${scene.id}`)
 	}
 

--- a/src/scene/migrate.tsx
+++ b/src/scene/migrate.tsx
@@ -1,0 +1,174 @@
+import { Scene, AssetLayer_Asset, FogLayer_LightSource, FogLayer_Polygon_PolygonType, AssetLayer_Asset_AssetType, FogLayer_Polygon } from '../protos/scene';
+import { IScene, newStorage, oldStorage } from './'
+import LayerType from "./layer/layerType";
+import { IAssetLayer } from "./layer/assetLayer";
+import { IFogLayer } from "./layer/fogLayer";
+import { defaultLightSource } from "./layer/fogLayer/rayCastRevealPolygon";
+import { IPolygon, PolygonType } from "./layer/editablePolygon";
+import { AssetType } from "./asset";
+import { tablePPI } from '../settings';
+
+function scaleAsset(asset: AssetLayer_Asset, scale: number): AssetLayer_Asset {
+  return {
+    ...asset,
+    size: {
+      width: asset.size!.width * scale,
+      height: asset.size!.height * scale
+    },
+    transform: {
+      x: asset.transform!.x! * scale,
+      y: asset.transform!.y! * scale,
+      width: asset.transform!.width! * scale,
+      height: asset.transform!.height! * scale,
+      rotation: asset.transform!.rotation
+    }
+  }
+}
+
+function scalePolygon(polygon: FogLayer_Polygon, scale: number): FogLayer_Polygon {
+  return {
+    type: polygon.type,
+    visibleOnTable: polygon.visibleOnTable,
+    verticies: polygon.verticies.map((v) => ({ x: v.x * scale, y: v.y * scale }))
+  }
+}
+
+function scaleScene(scene: Scene, scale: number): Scene {
+  console.log('scaling by ' + scale);
+  scene.table!.offset!.x = scene.table!.offset!.x * scale;
+  scene.table!.offset!.y = scene.table!.offset!.y * scale;
+  scene.table!.scale = scene.table!.scale / scale;
+
+  for (const layer of scene.layers) {
+    if (layer.assetLayer) {
+      const assetLayer = layer.assetLayer;
+      for (const [assetId, asset] of Object.entries(assetLayer.assets)) {
+        assetLayer.assets[assetId] = scaleAsset(asset, scale);
+      }
+    }
+    else if (layer.fogLayer) {
+      layer.fogLayer.lightSources = layer.fogLayer.lightSources.map((l) => ({
+        ...l, position: { x: l.position!.x * scale, y: l.position!.y * scale }
+      }))
+      layer.fogLayer.obstructionPolygons = layer.fogLayer.obstructionPolygons.map((p) => scalePolygon(p, scale));
+      layer.fogLayer.fogPolygons = layer.fogLayer.fogPolygons.map((p) => scalePolygon(p, scale));
+      layer.fogLayer.fogClearPolygons = layer.fogLayer.fogClearPolygons.map((p) => scalePolygon(p, scale));
+    }
+  }
+  return scene;
+}
+
+let migrating = false;
+export async function migrate() {
+  const scale = 1 / (await tablePPI());
+  const newSceneIds = await newStorage.storage.keys();
+  if (newSceneIds.length > 0 || migrating) {
+    console.log('Not migrating as it has already been migrated');
+    return;
+  }
+  
+  migrating = true;
+  const sceneIds = await oldStorage.storage.keys();
+  console.time('Done migrating ' + sceneIds.keys + ' scenes')
+  for (const sceneId of sceneIds) {
+    const oldScene = await oldStorage.storage.getItem(sceneId);
+
+    const newScene = newSceneFromOldScene(oldScene);
+    const scaledScene = scaleScene(newScene, scale);
+
+    await newStorage.createItem(sceneId, Scene.encode(scaledScene).finish());
+  }
+  console.timeEnd('Done migrating ' + sceneIds.keys + ' scenes')
+}
+
+export function newSceneFromOldScene(oldScene: IScene): Scene {
+  function polygonConvert(newPolygon: IPolygon): FogLayer_Polygon {
+    return {
+      ...newPolygon,
+      type: FogLayer_Polygon_PolygonType[PolygonType[newPolygon.type]]
+    }
+  }
+
+  return {
+    id: oldScene.id,
+    name: oldScene.name,
+    table: oldScene.table,
+    layers: oldScene.layers.map((layer) => {
+      if (layer.type === LayerType.ASSETS) {
+        const oldLayer = layer as IAssetLayer;
+        return {
+          assetLayer: {
+            id: oldLayer.id,
+            name: oldLayer.name,
+            visible: oldLayer.visible,
+            assets: Array.from(oldLayer.assets.values()).reduce((a, c) => ({ [c.id]: c, ...a }), {})
+          },
+          fogLayer: undefined
+        };
+      }
+      else if (layer.type === LayerType.FOG) {
+        const oldLayer = layer as IFogLayer;
+        return {
+          fogLayer: {
+            id: oldLayer.id,
+            name: oldLayer.name,
+            visible: oldLayer.visible,
+            lightSources: oldLayer.lightSources.map((l) => defaultLightSource(l) as FogLayer_LightSource),
+            obstructionPolygons: oldLayer.obstructionPolygons.map(polygonConvert),
+            fogPolygons: oldLayer.fogPolygons.map(polygonConvert),
+            fogClearPolygons: oldLayer.fogClearPolygons.map(polygonConvert)
+          },
+          assetLayer: undefined
+        };
+      }
+      else {
+        throw new Error('Unsupported layer type')
+      }
+    })
+  }
+}
+
+export function oldSceneFromNewScene(newScene: Scene): IScene {
+  function polygonConvert(newPolygon: FogLayer_Polygon): IPolygon {
+    return {
+      ...newPolygon,
+      type: PolygonType[FogLayer_Polygon_PolygonType[newPolygon.type]]
+    }
+  }
+
+  return {
+    id: newScene.id,
+    name: newScene.name,
+    table: newScene.table,
+    layers: newScene.layers.map((l) => {
+      if (l.assetLayer) {
+        return {
+          ...l.assetLayer,
+          type: LayerType.ASSETS,
+          assets: new Map(Object.entries(l.assetLayer.assets).map(([assetId, asset]) =>
+            [
+              assetId,
+              {
+                ...asset,
+                type: AssetType[AssetLayer_Asset_AssetType[asset.type]]
+              }
+            ]
+          ))
+        } as IAssetLayer;
+      }
+      else if (l.fogLayer) {
+
+        return {
+          ...l.fogLayer,
+          obstructionPolygons: l.fogLayer.obstructionPolygons.map(polygonConvert),
+          fogPolygons: l.fogLayer.fogPolygons.map(polygonConvert),
+          fogClearPolygons: l.fogLayer.fogClearPolygons.map(polygonConvert),
+          type: LayerType.FOG
+        } as IFogLayer
+      }
+      else {
+        throw new Error('Got a layer without it being asset or fog')
+      }
+    })
+  } as IScene;
+}

--- a/src/scene/oldStorage.tsx
+++ b/src/scene/oldStorage.tsx
@@ -1,0 +1,79 @@
+import Konva from 'konva';
+import globalStorage from '../storage';
+
+export enum OldLayerType {
+  ASSETS,
+  FOG,
+  TABLE_VIEW
+}
+export interface OldILayer {
+  id: string
+  type: OldLayerType
+  name: string
+  visible: boolean
+}
+export interface OldIAssetLayer extends OldILayer {
+	assets: Map<string, OldIAsset>
+}
+export enum OldAssetType {
+	IMAGE,
+	VIDEO
+}
+
+export interface OldIAssetCalibration {
+	xOffset: number;
+	yOffset: number;
+	ppiX: number;
+	ppiY: number;
+}
+export type OldAssetTransform = Konva.RectConfig & { rotation: number };
+
+export interface OldIAsset {
+	id: string;
+	size: { width: number, height: number };
+	transform: OldAssetTransform;
+	overrideCalibration?: boolean;
+	calibration?: OldIAssetCalibration
+	type: OldAssetType;
+	snapToGrid?: boolean
+}
+
+
+export enum OldPolygonType {
+  FOG,
+  FOG_CLEAR,
+  LIGHT_OBSTRUCTION
+}
+export interface OldIPolygon {
+  type: OldPolygonType,
+  verticies: Array<Konva.Vector2d>
+  visibleOnTable: boolean;
+}
+export interface OldILightSource {
+  position: Konva.Vector2d,
+  brightLightDistance?: number,
+  dimLightDistance?: number,
+}
+export interface OldIFogLayer extends OldILayer {
+  lightSources: Array<OldILightSource>;
+  obstructionPolygons: Array<OldIPolygon>;
+  fogPolygons: Array<OldIPolygon>;
+  fogClearPolygons: Array<OldIPolygon>;
+}
+
+export interface OldTableOptions {
+	displayGrid: boolean,
+	offset: Konva.Vector2d,
+	rotation: number,
+	scale: number,
+}
+
+export interface OldIScene {
+  id: string;
+  name: string;
+  version: number;
+  table: OldTableOptions,
+  layers: Array<OldILayer>;
+}
+
+export const oldStorage = globalStorage<OldIScene>('scene');

--- a/src/scene/page.tsx
+++ b/src/scene/page.tsx
@@ -4,7 +4,6 @@ import { Helmet } from 'react-helmet';
 import SceneEditor from "../scene/editor";
 import Menu from "./menu";
 
-
 type Props = {};
 const ScenePage: React.SFC<Props> = () => {
 

--- a/src/settings/index.tsx
+++ b/src/settings/index.tsx
@@ -53,6 +53,24 @@ export function useTableSize(): [number | undefined, (newValue: number) => Promi
   return [tableSize, setTableSize];
 }
 
+export function useTableDimensions() {
+  const [size] = useTableSize();
+  const [resolution] = useTableResolution();
+
+  if (!resolution || !size) {
+    return undefined;
+  }
+
+  const theta = Math.atan(resolution.height / resolution.width);
+  const widthInch = size * Math.cos(theta);
+  const heightInch = size * Math.sin(theta);
+
+  return {
+    width: widthInch,
+    height: heightInch
+  }
+}
+
 export function usePlayAudioOnTable(): [boolean | undefined, (newValue: boolean) => Promise<void>] {
   const [playAudio, setPlayAudio] = useOneSettingValue<boolean>(Settings.PLAY_AUDIO_ON_TABLE);
   if (playAudio === null) {
@@ -72,8 +90,12 @@ export async function tablePPI() {
 
 	if (!resolution || !size) {
 		resolution = { width: 3840, height: 2160 };
-		size = 45;
 	}
+  if (!size) {
+    size = 45;
+  }
+
+  console.log({resolution,size})
 
 	const theta = Math.atan(resolution.height / resolution.width);
   const widthInch = size * Math.cos(theta);
@@ -84,17 +106,14 @@ export async function tablePPI() {
 }
 
 export function useTablePPI(): number | null {
-  const [tableResolution] = useTableResolution();
-  const [tableSize] = useTableSize();
-  if (!tableResolution || !tableSize) {
+  const [resolution] = useTableResolution();
+  const tableDimensions = useTableDimensions();
+
+  if (!resolution || !tableDimensions) {
     return null;
   }
 
-  const theta = Math.atan(tableResolution.height / tableResolution.width);
-  const widthInch = tableSize * Math.cos(theta);
-  // const heightInch = tableSize * Math.sin(theta);
-
-  const ppi = tableResolution.width / widthInch;
+  const ppi = resolution.width / tableDimensions.width;
   return ppi;
 }
 

--- a/src/settings/index.tsx
+++ b/src/settings/index.tsx
@@ -3,13 +3,11 @@ import React from "react";
 import Box from '@mui/material/Box'
 import Switch from '@mui/material/Switch'
 import FormControlLabel from '@mui/material/FormControlLabel'
-import Button from '@mui/material/Button'
 
 import globalStorage from "../storage";
 import theme from "../theme";
 import InputWithUnit from "../partials/inputWithUnit";
 import InputGroup from "../partials/inputGroup";
-import { migrate } from '../scene/migrate';
 
 export enum Settings {
   DISPLAYED_SCENE = 'displayed_scene',
@@ -94,8 +92,6 @@ export async function tablePPI() {
   if (!size) {
     size = 45;
   }
-
-  console.log({resolution,size})
 
 	const theta = Math.atan(resolution.height / resolution.width);
   const widthInch = size * Math.cos(theta);
@@ -186,8 +182,6 @@ const ScreenSizeSettings: React.FunctionComponent = () => {
           }
           label="Play Audio on Table"
         />
-
-        <Button onClick={() => migrate()}>Migrate Scenes</Button>
       </InputGroup>
     </>
   );

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 const RTStorage = require('rt-storage');
 
-interface IRTStorage<T> {
+export interface IRTStorage<T> {
 	getItem<V extends T>(key: string): Promise<V>;
 	setItem<V extends T>(key: string, value: V): Promise<V>;
 	removeItem(key: string): Promise<void>;

--- a/src/table/page.tsx
+++ b/src/table/page.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { settingsDatabase, Settings, useTableResolution, useTablePPI } from '../settings';
-import { sceneDatabase, IScene } from '../scene';
 import { Stage } from 'react-konva';
 import { Helmet } from 'react-helmet';
-import { LayerTypeToComponent } from '../scene/layer';
-import TableViewOverlay, { TableViewLayer } from '../scene/layer/tableView';
-import { CurrentSceneContext } from '../scene/canvas';
+
+import { settingsDatabase, Settings, useTableResolution, useTablePPI } from '../settings';
+import { sceneDatabase } from '../scene';
+import { flattenLayer, LayerTypeToComponent } from '../scene/layer';
+import TableViewOverlay from '../scene/layer/tableView';
+import * as Types from '../protos/scene';
 
 const { useOneValue } = sceneDatabase();
 const { useOneValue: useOneSettingValue } = settingsDatabase();
@@ -17,18 +18,21 @@ const TablePage: React.FunctionComponent<Props> = () => {
 	const [tableResolution] = useTableResolution();
 
 	const [scene] = useOneValue(displayedScene as string);
-	const [tableScene, setTableScene] = useState<IScene | null>(null);
+	const [tableScene, setTableScene] = useState<Types.Scene | null>(null);
 
 	const tablePPI = useTablePPI();
 
 	useEffect(() => {
-		if (!tableFreeze && scene !== undefined) {
+		if (scene === null || displayedScene === null) {
+			setTableScene(null)
+		}
+		else if (!tableFreeze && scene !== undefined) {
 			if (scene === null) setTableScene(null)
 			else if (scene.version !== tableScene?.version) {
 				setTableScene(scene);
 			}
 		}
-	}, [scene, tableScene, tableFreeze])
+	}, [displayedScene, scene, tableScene, tableFreeze])
 
 	if (!tableResolution || !tablePPI) {
 		return null;
@@ -41,39 +45,32 @@ const TablePage: React.FunctionComponent<Props> = () => {
 				<Stage
 					width={tableResolution.width}
 					height={tableResolution.height}
-					offsetX={tableScene.table.offset.x}
-					offsetY={tableScene.table.offset.y}
-					scaleX={tableScene.table.scale * tablePPI}
-					scaleY={tableScene.table.scale * tablePPI}
+					offsetX={tableScene.table!.offset!.x}
+					offsetY={tableScene.table!.offset!.y}
+					scaleX={tableScene.table!.scale * tablePPI}
+					scaleY={tableScene.table!.scale * tablePPI}
 				>
-					<CurrentSceneContext.Provider value={tableScene}>
-						{
-							tableScene.layers.map((layer) => {
-								const Component = LayerTypeToComponent[layer.type];
-								if (!Component || layer.visible === false) return null;
-								return (
-									<Component
-										key={layer.id}
-										isTable={true}
-										layer={layer}
-										onUpdate={() => { }}
-										active={false}
-									/>
-								);
-							})
-						}
-						<TableViewOverlay
-							layer={{
-								...TableViewLayer,
-								options: tableScene.table
-							}}
-							isTable={true}
-							active={false}
-							onUpdate={() => { }}
-							showBorder={false}
-							showGrid={tableScene.table.displayGrid}
-						/>
-					</CurrentSceneContext.Provider>
+					{tableScene.layers.map(flattenLayer).map((layer) => {
+						const Component = LayerTypeToComponent[layer.type];
+						if (!Component || layer.visible === false) return null;
+						return (
+							<Component
+								key={layer.id}
+								isTable={true}
+								layer={layer}
+								onUpdate={() => { }}
+								active={false}
+							/>
+						);
+					})
+					}
+					<TableViewOverlay
+						options={tableScene.table!}
+						active={false}
+						onUpdate={() => { }}
+						showBorder={false}
+						showGrid={tableScene.table!.displayGrid}
+					/>
 				</Stage>
 			}
 		</>

--- a/src/table/page.tsx
+++ b/src/table/page.tsx
@@ -6,7 +6,6 @@ import { Helmet } from 'react-helmet';
 import { LayerTypeToComponent } from '../scene/layer';
 import TableViewOverlay, { TableViewLayer } from '../scene/layer/tableView';
 import { CurrentSceneContext } from '../scene/canvas';
-import { BLUR_RADIUS } from '../scene/layer/fogLayer';
 
 const { useOneValue } = sceneDatabase();
 const { useOneValue: useOneSettingValue } = settingsDatabase();
@@ -22,15 +21,16 @@ const TablePage: React.FunctionComponent<Props> = () => {
 
 	const tablePPI = useTablePPI();
 
-	const BLUR_OFFSET = (tablePPI || 100) * BLUR_RADIUS * 2;
-
 	useEffect(() => {
 		if (!tableFreeze && scene !== undefined) {
-			setTableScene(scene);
+			if (scene === null) setTableScene(null)
+			else if (scene.version !== tableScene?.version) {
+				setTableScene(scene);
+			}
 		}
-	}, [scene, tableFreeze])
+	}, [scene, tableScene, tableFreeze])
 
-	if (!tableResolution) {
+	if (!tableResolution || !tablePPI) {
 		return null;
 	}
 
@@ -39,18 +39,12 @@ const TablePage: React.FunctionComponent<Props> = () => {
 			<Helmet title="D&amp;D Table View" />
 			{tableScene &&
 				<Stage
-					width={tableResolution.width + BLUR_OFFSET * 2}
-					height={tableResolution.height + BLUR_OFFSET * 2}
-					offsetX={tableScene.table.offset.x - BLUR_OFFSET}
-					offsetY={tableScene.table.offset.y - BLUR_OFFSET}
-					scaleX={tableScene.table.scale}
-					scaleY={tableScene.table.scale}
-					style={{
-						position: 'relative',
-						top: `${-BLUR_OFFSET}px`,
-						left: `${-BLUR_OFFSET}px`,
-						backgroundColor: 'black'
-					}}
+					width={tableResolution.width}
+					height={tableResolution.height}
+					offsetX={tableScene.table.offset.x}
+					offsetY={tableScene.table.offset.y}
+					scaleX={tableScene.table.scale * tablePPI}
+					scaleY={tableScene.table.scale * tablePPI}
 				>
 					<CurrentSceneContext.Provider value={tableScene}>
 						{

--- a/src/table/page.tsx
+++ b/src/table/page.tsx
@@ -20,7 +20,6 @@ const TablePage: React.FunctionComponent<Props> = () => {
 	const [scene] = useOneValue(displayedScene as string);
 	const [tableScene, setTableScene] = useState<IScene | null>(null);
 
-	const [windowSize, setWindowSize] = useState({ width: window.innerWidth, height: window.innerHeight })
 	const tablePPI = useTablePPI();
 
 	const BLUR_OFFSET = (tablePPI || 100) * BLUR_RADIUS * 2;
@@ -31,14 +30,6 @@ const TablePage: React.FunctionComponent<Props> = () => {
 		}
 	}, [scene, tableFreeze])
 
-	useEffect(() => {
-		function onResize() {
-			setWindowSize({ width: window.innerWidth, height: window.innerHeight });
-		}
-		window.addEventListener('resize', onResize);
-		return () => window.removeEventListener('resize', onResize)
-	}, [])
-
 	if (!tableResolution) {
 		return null;
 	}
@@ -48,8 +39,8 @@ const TablePage: React.FunctionComponent<Props> = () => {
 			<Helmet title="D&amp;D Table View" />
 			{tableScene &&
 				<Stage
-					width={windowSize.width + BLUR_OFFSET * 2}
-					height={windowSize.height + BLUR_OFFSET * 2}
+					width={tableResolution.width + BLUR_OFFSET * 2}
+					height={tableResolution.height + BLUR_OFFSET * 2}
 					offsetX={tableScene.table.offset.x - BLUR_OFFSET}
 					offsetY={tableScene.table.offset.y - BLUR_OFFSET}
 					scaleX={tableScene.table.scale}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
   "files": [ "./src/index.tsx", "./src/react-app-env.d.ts"],
   "exclude": [
     "node_modules",
-    "**/*.test.ts"
+    "**/*.test.ts",
+    "src/protos/**.ts"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1506,6 +1506,59 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.0.tgz#6734f8ebc106a0860dff7f92bf90df193f0935d7"
   integrity sha512-zrsUxjLOKAzdewIDRWy9nsV1GQsKBCWaGwsZQlCgr6/q+vjyZhFgqedLfFBuI9anTPEUT4APq9Mu0SZBTzIcGQ==
 
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha1-m4sMxmPWaafY9vXQiToU00jzD78=
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+
 "@rehooks/component-size@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@rehooks/component-size/-/component-size-1.0.3.tgz#823eabeb42084893d46d43e3a9d1d0e34252b3cb"
@@ -1859,6 +1912,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/long@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
+  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
+
 "@types/lru-cache@^5.1.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
@@ -1874,10 +1932,20 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.4.tgz#fec0ce0526abb6062fd206d72a642811b887a111"
   integrity sha512-6xwbrW4JJiJLgF+zNypN5wr2ykM9/jHcL7rQ8fZe2vuftggjzZeRSM4OwRc6Xk8qWjwJ99qVHo/JgOGmomWRog==
 
+"@types/node@>=13.7.0":
+  version "17.0.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.5.tgz#57ca67ec4e57ad9e4ef5a6bab48a15387a1c83e0"
+  integrity sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==
+
 "@types/node@^14.0.12":
   version "14.18.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.2.tgz#00fe4d1686d5f6cf3a2f2e9a0eef42594d06abfc"
   integrity sha512-fqtSN5xn/bBzDxMT77C1rJg6CsH/R49E7qsGuvdPJa20HtV5zSTuLJPNfnlyVH3wauKnkHdLggTVkOW/xP9oQg==
+
+"@types/object-hash@^1.3.0":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@types/object-hash/-/object-hash-1.3.4.tgz#079ba142be65833293673254831b5e3e847fe58b"
+  integrity sha512-xFdpkAkikBgqBdG9vIlsqffDV8GpvnPEzs0IUtr1v3BEB97ijsFQ4RXVbUZwjFThhB4MDSTUfvmxUD5PGx0wXA==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -3395,6 +3463,11 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
+
+dataloader@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
+  integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
 
 debug@2.6.9, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
@@ -5865,10 +5938,15 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.14, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -6131,6 +6209,11 @@ object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
+object-hash@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
+  integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
 
 object-hash@^2.2.0:
   version "2.2.0"
@@ -7006,6 +7089,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
+
 pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
@@ -7062,6 +7150,25 @@ prop-types@^15.6.2, prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+protobufjs@^6.11.2, protobufjs@^6.8.8:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.2.tgz#de39fabd4ed32beaa08e9bb1e30d08544c1edf8b"
+  integrity sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.1"
+    "@types/node" ">=13.7.0"
+    long "^4.0.0"
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -8295,6 +8402,34 @@ tryer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+
+ts-poet@^4.5.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/ts-poet/-/ts-poet-4.7.0.tgz#c474621cf0d7ce53bebc3cf55fbc7154e5ad8546"
+  integrity sha512-Bh2vgwgREKcGsfV7Lx3nokLBf2hBrZYBZDw5/s20YV2IxDObMBVRQ0kVmYGtnCXJ6JLf7esFKbwzdMLelNs6XA==
+  dependencies:
+    lodash "^4.17.15"
+    prettier "^2.5.1"
+
+ts-proto-descriptors@^1.2.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/ts-proto-descriptors/-/ts-proto-descriptors-1.3.1.tgz#760ebaaa19475b03662f7b358ffea45b9c5348f5"
+  integrity sha512-Cybb3fqceMwA6JzHdC32dIo8eVGVmXrM6TWhdk1XQVVHT/6OQqk0ioyX1dIdu3rCIBhRmWUhUE4HsyK+olmgMw==
+  dependencies:
+    long "^4.0.0"
+    protobufjs "^6.8.8"
+
+ts-proto@^1.96.1:
+  version "1.96.1"
+  resolved "https://registry.yarnpkg.com/ts-proto/-/ts-proto-1.96.1.tgz#05ab0bb8b91a3cb738ce407c4664c8b461bc5ded"
+  integrity sha512-Tji2/afX5AbAs9xTr+JbKt9SoJw3Kp3+gjnjursjazS5jyz92H+dpYXcxeqCOH3rjApn684ml/rgC+zkQ3HXzw==
+  dependencies:
+    "@types/object-hash" "^1.3.0"
+    dataloader "^1.4.0"
+    object-hash "^1.3.1"
+    protobufjs "^6.8.8"
+    ts-poet "^4.5.0"
+    ts-proto-descriptors "^1.2.1"
 
 tsconfig-paths@^3.11.0:
   version "3.12.0"


### PR DESCRIPTION
This changes the way the scenes are stored in IndexedDB to use Protobufs instead of JSON. This will allow for better support for things like https://github.com/tutman96/dnd-tabletop/issues/44 and https://github.com/tutman96/dnd-tabletop/issues/20.

This also changes the units that everything is based off of. Instead of all of the dimensions in the scene being based off of pixels, it is instead based off of inches. This allows the display resolution to be adjusted without affecting the grid spacing against the assets. It also makes the code cleaner as everything use to have to multiply things by the screen PPI.

## Note
The migration is non-destructive as it introduces another database to store the new serialization format. The old database will stick around for a while until everyone has been migrated, at which point the code will be removed for it. If there is something wrong in the migration, this PR can be reverted and all scenes will go back to what they were before the migration.